### PR TITLE
HDS-42 fix build error and provide default values for service category and vendor level

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeedCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeedCommand.cs
@@ -350,7 +350,7 @@ namespace Headstart.API.Commands
 		{
 			foreach (var messageSender in DefaultMessageSenders())
 			{
-				messageSender.URL = $"{_settings.EnvironmentSettings.BaseUrl}{messageSender.URL}";
+				messageSender.URL = $"{_settings.EnvironmentSettings.MiddlewareBaseUrl}{messageSender.URL}";
 				await _oc.MessageSenders.SaveAsync(messageSender.ID, messageSender, accessToken);
 			}
 		}

--- a/src/Middleware/src/Headstart.API/Controllers/SupplierCategoryConfigController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/SupplierCategoryConfigController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using OrderCloud.SDK;
 using System.Threading.Tasks;
 using Headstart.Models.Attributes;
@@ -78,7 +78,11 @@ namespace Headstart.Common.Controllers
 					BuyerAppFilterType = "SelectOption",
 					Items = new List<Filter>
 					{
-
+						new Filter
+                        {
+							Text = "Default Service Category",
+							Value = "DefaultServiceCategory"
+						}
 					}
 				}
 			};
@@ -98,7 +102,11 @@ namespace Headstart.Common.Controllers
 					BuyerAppFilterType = "SelectOption",
 					Items = new List<Filter>
 					{
-
+						new Filter
+                        {
+							Text = "Default Vendor Level",
+							Value = "DefaultVendorLevel"
+                        }
 					}
 				}
 			};

--- a/src/Middleware/src/Headstart.Common/AppSettings.cs
+++ b/src/Middleware/src/Headstart.Common/AppSettings.cs
@@ -42,7 +42,7 @@ namespace Headstart.Common
         public AppEnvironment Environment { get; set; }
         public string BuildNumber { get; set; } // set during deploy
         public string Commit { get; set; } // set during deploy
-        public string BaseUrl { get; set; }
+        public string MiddlewareBaseUrl { get; set; }
         public string AFStorefrontBaseUrl { get; set; }
         public string AFStorefrontClientID { get; set; }
         public string WTCStorefrontBaseUrl { get; set; }


### PR DESCRIPTION
## Description
Unable to create a vendor without defining defaults for service category and vendor level. I think this is too specific to be useful so we'll want to take this out at a later time but the quickest fix so it doesn't block anyone is to stub some defaults.

For Reference  HDS-42

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the acceptance criteria on the task so that it can be tested
- [ ] I have verified my contribution works and looks well in Firefox, Safari and Internet Explorer
