### PR TITLE
SEB-1561 ensure PO shipping is not applied to credit card

### DIFF
--- a/src/Middleware/src/Headstart.Common/Extensions/Extensions.cs
+++ b/src/Middleware/src/Headstart.Common/Extensions/Extensions.cs
@@ -1,4 +1,5 @@
 using Headstart.Common.Services.ShippingIntegration.Models;
+using Headstart.Models;
 using Headstart.Models.Headstart;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,6 +38,11 @@ namespace Headstart.Common.Extensions
         public static IEnumerable<HSLineItem> GetBuyerLineItemsBySupplierID(this HSOrderWorksheet buyerWorksheet, string supplierID)
         {
             return buyerWorksheet?.LineItems?.Where(li => li.SupplierID == supplierID).Select(li => li);
+        }
+
+        public static IEnumerable<HSLineItem> GetLineItemsByProductType(this HSOrderWorksheet buyerWorksheet, ProductType type)
+        {
+            return buyerWorksheet?.LineItems.Where(li => li.Product.xp.ProductType == type);
         }
     }
 }

--- a/src/Middleware/src/Headstart.Common/Services/OrderCalcService.cs
+++ b/src/Middleware/src/Headstart.Common/Services/OrderCalcService.cs
@@ -1,4 +1,5 @@
-﻿using Headstart.Common.Services.ShippingIntegration.Models;
+﻿using Headstart.Common.Extensions;
+using Headstart.Common.Services.ShippingIntegration.Models;
 using Headstart.Models;
 using ordercloud.integrations.exchangerates;
 using ordercloud.integrations.library;
@@ -33,10 +34,30 @@ namespace Headstart.Common.Services
 
         public decimal GetPurchaseOrderTotal(HSOrderWorksheet worksheet)
         {
-            return worksheet.LineItems
+            var shippingTotal = GetPurchaseOrderShipping(worksheet);
+            return worksheet.GetLineItemsByProductType(ProductType.PurchaseOrder)
                 .Where(li => li.Product.xp.ProductType == ProductType.PurchaseOrder)
                 .Select(li => li.LineTotal)
-                .Sum();
+                .Sum() + shippingTotal;
+        }
+
+        public decimal GetPurchaseOrderShipping(HSOrderWorksheet worksheet)
+        {
+            decimal POShippingCosts = 0;
+            var POlineItemIDs = worksheet.GetLineItemsByProductType(ProductType.PurchaseOrder)?.Select(li => li.ID);
+            if (POlineItemIDs?.Count() > 0)
+            {
+                foreach (var estimate in worksheet?.ShipEstimateResponse?.ShipEstimates)
+                {
+                    var relatedLineItemIDs = estimate?.ShipEstimateItems?.Select(item => item?.LineItemID);
+                    var selectedShipMethod = estimate?.ShipMethods?.FirstOrDefault(method => method?.ID == estimate?.SelectedShipMethodID);
+                    if (relatedLineItemIDs != null && relatedLineItemIDs.Any(id => POlineItemIDs.Contains(id)))
+                    {
+                        POShippingCosts = POShippingCosts + (selectedShipMethod?.Cost ?? 0);
+                    }
+                }
+            }
+            return POShippingCosts;
         }
     }
 }


### PR DESCRIPTION
## Description

SEB-1561. This prevents shipping charges for PO line items from being applied to credit card charges in mixed orders.

For Reference # SEB-1561

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
