### PR TITLE
HDS-91 update currency cache if it is not there

### DIFF
--- a/src/Middleware/integrations/ordercloud.integrations.exchangerates/ExchangeRatesCommand.cs
+++ b/src/Middleware/integrations/ordercloud.integrations.exchangerates/ExchangeRatesCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -53,7 +53,18 @@ namespace ordercloud.integrations.exchangerates
         /// <returns></returns>
         public async Task<ListPage<OrderCloudIntegrationsConversionRate>> Get(ListArgs<OrderCloudIntegrationsConversionRate> rateArgs, CurrencySymbol currency)
         {
+            try
+            {
+                return await GetCachedRates(rateArgs, currency);
+            } catch (Exception ex)
+            {
+                await Update();
+                return await GetCachedRates(rateArgs, currency);
+            }   
+        }
 
+        private async Task<ListPage<OrderCloudIntegrationsConversionRate>> GetCachedRates(ListArgs<OrderCloudIntegrationsConversionRate> rateArgs, CurrencySymbol currency)
+        {
             var rates = await _cache.GetOrAddAsync($"exchangerates_{currency}", () => {
                 return _blob.Get<OrderCloudIntegrationsExchangeRate>($"{currency}.json");
             }, TimeSpan.FromHours(1));


### PR DESCRIPTION
## Description

Buyer users on the base app demo site are not able to log in. This is because the call to get exchange rates by currency fails. The reason it is failing is because there is no currency.json in the org's blob storage. 

I added a catch to update and set the currency.json file if there is not one stored there. This will allow the cache to get updated on failed calls and allow users to login.

For Reference # [HDS-91]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes


[HDS-91]: https://four51.atlassian.net/browse/HDS-91