### PR TITLE
HDS-89 Do not display "invalid credentials" on contentful error

### DIFF
--- a/src/UI/Seller/src/app/shared/services/current-user/current-user.service.ts
+++ b/src/UI/Seller/src/app/shared/services/current-user/current-user.service.ts
@@ -61,6 +61,19 @@ export class CurrentUserService {
     this.appStateService.isLoggedIn.next(true)
     this.me = await this.ocMeService.Get().toPromise()
     this.userSubject.next(this.me)
+    if (this.me?.Supplier) {
+      this.mySupplier = await HeadStartSDK.Suppliers.GetMySupplier(
+        this.me?.Supplier?.ID
+      )
+    }
+    try {
+      await this.setImageAssets()
+    } catch(err) {
+      // do not display login error if problem in getting assets
+    }
+  }
+
+  async setImageAssets() {
     let imgAssets: ListPage<Asset>
     if (this.me.Supplier) {
       imgAssets = await ContentManagementClient.Assets.ListAssetsOnChild(
@@ -79,10 +92,6 @@ export class CurrentUserService {
     }
     if (imgAssets.Items.length > 0)
       this.profileImgSubject.next(imgAssets.Items[0])
-    if (this.me?.Supplier)
-      this.mySupplier = await HeadStartSDK.Suppliers.GetMySupplier(
-        this.me?.Supplier?.ID
-      )
   }
 
   async getUser(): Promise<MeUser> {

--- a/src/UI/Seller/src/assets/appConfigs/defaultadmin-test.json
+++ b/src/UI/Seller/src/assets/appConfigs/defaultadmin-test.json
@@ -1,19 +1,19 @@
 {
-    "hostedApp": true,
-    "sellerID": "my-seller-id",
-    "sellerName": "Default Admin",
-    "appname": "Default Admin",
-    "clientID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    "middlewareUrl": "https://my-default-admin-test.com",
-    "cmsUrl": "https://ordercloud-cms-test.azurewebsites.net",
-    "translateBlobUrl": "https://my-translation-files/ngx-translate/i18n/",
-    "blobStorageUrl": "https://myblobstoragecontainer.blob.core.windows.net",
-    "orderCloudApiUrl": "https://sandboxapi.ordercloud.io",
-    "buyerConfigs": {
-      "Default Buyer": {
-        "clientID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        "buyerUrl": "https://my-default-buyer-test.com/"
-      }
-    },
-    "superProductFieldsToMonitor": []
-  }
+  "hostedApp": true,
+  "sellerID": "my-seller-id",
+  "sellerName": "Default Admin",
+  "appname": "Default Admin",
+  "clientID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "middlewareUrl": "https://my-default-admin-test.com",
+  "cmsUrl": "https://ordercloud-cms-test.azurewebsites.net",
+  "translateBlobUrl": "https://my-translation-files/ngx-translate/i18n/",
+  "blobStorageUrl": "https://myblobstoragecontainer.blob.core.windows.net",
+  "orderCloudApiUrl": "https://sandboxapi.ordercloud.io",
+  "buyerConfigs": {
+    "Default Buyer": {
+      "clientID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      "buyerUrl": "https://my-default-buyer-test.com/"
+    }
+  },
+  "superProductFieldsToMonitor": []
+}


### PR DESCRIPTION
## Description

Prevent "Invalid credentials" error from displaying if there is an error in attempting to get users profile image.

For Reference # [HDS-89]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code


[HDS-89]: https://four51.atlassian.net/browse/HDS-89