### PR TITLE
hds-107 - Remove orchestration logs from navbar

### DIFF
--- a/src/UI/Seller/src/app/layout/header/header.config.ts
+++ b/src/UI/Seller/src/app/layout/header/header.config.ts
@@ -235,7 +235,7 @@ const ProcessReports = {
 
 const ReportTemplates = {
   rolesWithAccess: [HSRoles.HSReportAdmin],
-  title: 'ADMIN.NAV.REPORT_TEHSLATES',
+  title: 'ADMIN.NAV.REPORT_TEMPLATES',
   route: `reports/${REDIRECT_TO_FIRST_PARENT}/templates`,
 }
 
@@ -243,7 +243,7 @@ const ReportsNavGrouping = {
   rolesWithAccess: [HSRoles.HSReportAdmin, HSRoles.HSReportReader],
   title: 'ADMIN.NAV.REPORTS',
   route: '/reports',
-  subRoutes: [OrchestrationLogs, ProcessReports, ReportTemplates],
+  subRoutes: [ProcessReports, ReportTemplates],
 }
 
 const SellerUsers = {


### PR DESCRIPTION
## Description

Orchestration logs not set up in Headstart. since it's not needed, we will hide it from the navbar.

Also fixing a typo. not sure what a "TEHSLATES" is.
For Reference # https://four51.atlassian.net/browse/HDS-107
## Type of change

<!-- Please delete options that are not relevant -->

- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x ] I have performed a self-review of my own code
