### PR TITLE
use slice pipe on resource table views so header items don't overlap.

### DIFF
--- a/src/UI/Seller/src/app/shared/components/resource-select-dropdown/resource-select-dropdown.component.html
+++ b/src/UI/Seller/src/app/shared/components/resource-select-dropdown/resource-select-dropdown.component.html
@@ -1,11 +1,13 @@
 <!-- parent resource dropdown -->
 <div ngbDropdown class="parent-resource-dropdown btn-block">
   <button
-    class="resource-btn btn btn-outline-dark additional-item-resource-select-dropdown"
+    class="resource-btn btn btn-outline-dark additional-item-resource-select-dropdown parent-resource"
     id="parentresourcedropdown"
     ngbDropdownToggle
   >
-    {{ selectedParentResourceName }}
+    <!--Limit display length to keep elements from overlapping -->
+    {{ selectedParentResourceName | slice: 0:34 }}
+    <span *ngIf="selectedParentResourceName.length > 35"> ...</span>
   </button>
   <div ngbDropdownMenu aria-labelledby="parent resource dropdown">
     <search-component

--- a/src/UI/Seller/src/app/shared/components/resource-select-dropdown/resource-select-dropdown.component.html
+++ b/src/UI/Seller/src/app/shared/components/resource-select-dropdown/resource-select-dropdown.component.html
@@ -1,7 +1,7 @@
 <!-- parent resource dropdown -->
 <div ngbDropdown class="parent-resource-dropdown btn-block">
   <button
-    class="resource-btn btn btn-outline-dark additional-item-resource-select-dropdown parent-resource"
+    class="resource-btn btn btn-outline-dark additional-item-resource-select-dropdown"
     id="parentresourcedropdown"
     ngbDropdownToggle
   >

--- a/src/UI/Seller/src/app/shared/components/user-group-assignments/user-group-assignments.component.html
+++ b/src/UI/Seller/src/app/shared/components/user-group-assignments/user-group-assignments.component.html
@@ -91,12 +91,14 @@
               <span
                 *ngIf="!searchTermInput && viewAssignedUserGroups"
                 class="font-italic"
-                >This user has not been assigned to any locations.</span
+                >This user has not been assigned to any supplier
+                addresses.</span
               >
               <span
                 *ngIf="!searchTermInput && !viewAssignedUserGroups"
                 class="font-italic"
-                >There are no locations for this user's Home Country.</span
+                >There are no supplier addresses for this user's Home
+                Country.</span
               >
             </td>
           </tr>


### PR DESCRIPTION
## Description

Cut off names after 35 characters and display ellipses instead to not cut off header buttons.

For Reference https://four51.atlassian.net/browse/HDS-121

## Type of change

<!-- Please delete options that are not relevant -->

- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x ] I have performed a self-review of my own code
