### PR TITLE
HDS-124 fix impersonation and make configurable

### DIFF
--- a/src/Middleware/src/Headstart.Common/Models/Headstart/HSBuyer.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Headstart/HSBuyer.cs
@@ -8,6 +8,7 @@ namespace Headstart.Models
     {
         public HSBuyer Buyer { get; set; }
         public BuyerMarkup Markup { get; set; }
+        public ImpersonationConfig ImpersonationConfig { get; set; }
     }
 
     [SwaggerModel]
@@ -29,5 +30,6 @@ namespace Headstart.Models
         // temporary field while waiting on content docs
         public int MarkupPercent { get; set; }
         public string ChiliPublishFolder { get; set; }
+        public string URL { get; set; }
     }
 }

--- a/src/UI/Seller/src/app/buyers/components/buyers/buyer-edit/buyer-edit.component.html
+++ b/src/UI/Seller/src/app/buyers/components/buyers/buyer-edit/buyer-edit.component.html
@@ -52,6 +52,52 @@
             placeholder="Enter Markup"
           />
         </div>
+        <div class="form-group">
+          <p class="mb-1">Allow Impersonation</p>
+          <label class="switch mb-0" for="ImpersonatingEnabled">
+            <input
+              type="checkbox"
+              class="form-check-input"
+              id="ImpersonatingEnabled"
+              showErrors
+              [resourceForm]="resourceForm"
+              aria-describedby="ImpersonatingEnabled"
+              formControlName="ImpersonatingEnabled"
+              (input)="updateResourceFromEvent($event, 'ImpersonatingEnabled')"
+            />
+            <span class="slider round cursor-pointer"></span>
+          </label>
+        </div>
+        <div class="form-group" *ngIf="showImpersonation">
+          <label for="Name">Buyer Site URL</label>
+          <input
+            type="text"
+            class="form-control"
+            id="URL"
+            showErrors
+            aria-describedby="URL"
+            maxlength="100"
+            [resourceForm]="resourceForm"
+            formControlName="URL"
+            (input)="updateResourceFromEvent($event, 'Buyer.xp.URL')"
+            placeholder="Enter Url used by buyer site"
+          />
+        </div>
+        <div class="form-group" *ngIf="showImpersonation">
+          <label for="Name">Buyer Site Client ID</label>
+          <input
+            type="text"
+            class="form-control"
+            id="ClientID"
+            showErrors
+            aria-describedby="ClientID"
+            maxlength="100"
+            [resourceForm]="resourceForm"
+            formControlName="ClientID"
+            (input)="updateResourceFromEvent($event, 'ImpersonationConfig.ClientID')"
+            placeholder="Enter client ID used by buyer site"
+          />
+        </div>
       </div>
     </div>
   </form>

--- a/src/UI/Seller/src/app/buyers/components/buyers/buyer-edit/buyer-edit.component.ts
+++ b/src/UI/Seller/src/app/buyers/components/buyers/buyer-edit/buyer-edit.component.ts
@@ -45,12 +45,12 @@ export class BuyerEditComponent implements OnDestroy {
     private router: Router,
     private buyerTempService: BuyerTempService,
     private appAuthService: AppAuthService
-  ) {}
+  ) { }
 
   updateResourceFromEvent(event: any, field: string): void {
     let resourceUpdate: ResourceFormUpdate;
-    if(field==="ImpersonatingEnabled") {
-      resourceUpdate= {
+    if (field === "ImpersonatingEnabled") {
+      resourceUpdate = {
         field: 'ImpersonationConfig',
         value: this.showImpersonation ? null : this._superBuyerStatic?.ImpersonationConfig,
         form: this.resourceForm
@@ -58,9 +58,9 @@ export class BuyerEditComponent implements OnDestroy {
       this.showImpersonation = !this.showImpersonation
     } else {
       const value =
-      field === 'Buyer.Active' ? event.target.checked : event.target.value
-      resourceUpdate = { 
-        field, 
+        field === 'Buyer.Active' ? event.target.checked : event.target.value
+      resourceUpdate = {
+        field,
         value,
         form: this.resourceForm
       }
@@ -73,7 +73,7 @@ export class BuyerEditComponent implements OnDestroy {
   }
 
   createBuyerForm(superBuyer: any): void {
-    const {Buyer, Markup, ImpersonationConfig} = superBuyer;
+    const { Buyer, Markup, ImpersonationConfig } = superBuyer;
     this.showImpersonation = ImpersonationConfig && ImpersonationConfig !== null
 
     this.resourceForm = new FormGroup({
@@ -83,7 +83,7 @@ export class BuyerEditComponent implements OnDestroy {
       ChiliPublishFolder: new FormControl(Buyer.xp.ChiliPublishFolder),
       ImpersonatingEnabled: new FormControl(this.showImpersonation),
       URL: new FormControl((Buyer.xp as any).URL),
-      ClientID: new FormControl(ImpersonationConfig?.ClientID) 
+      ClientID: new FormControl(ImpersonationConfig?.ClientID)
     })
     this.setImpersonationValidator()
   }
@@ -92,13 +92,13 @@ export class BuyerEditComponent implements OnDestroy {
     const url = this.resourceForm.get('URL')
     const ClientID = this.resourceForm.get('ClientID')
     this.impersonationSubscription = this.resourceForm
-    .get('ImpersonatingEnabled')
-    .valueChanges.subscribe((impersonation) => {
-      if(impersonation) {
-        url.setValidators([Validators.required])
-        ClientID.setValidators([Validators.required, Validators.minLength(36)])
-      }
-    })
+      .get('ImpersonatingEnabled')
+      .valueChanges.subscribe((impersonation) => {
+        if (impersonation) {
+          url.setValidators([Validators.required])
+          ClientID.setValidators([Validators.required, Validators.minLength(36)])
+        }
+      })
   }
 
   async handleSelectedBuyerChange(buyer: HSBuyer): Promise<void> {

--- a/src/UI/Seller/src/app/models/buyer-markups.types.ts
+++ b/src/UI/Seller/src/app/models/buyer-markups.types.ts
@@ -1,8 +1,11 @@
+import { ImpersonationConfig } from '@ordercloud/angular-sdk';
 import { HSBuyer } from '@ordercloud/headstart-sdk'
+import { Buyer } from 'ordercloud-javascript-sdk';
 
 export interface HSBuyerPriceMarkup {
-  Buyer: HSBuyer
+  Buyer: Buyer //todo replace with HSBuyer once sdk is updated
   Markup: BuyerMarkup
+  ImpersonationConfig?: ImpersonationConfig
 }
 
 interface BuyerMarkup {

--- a/src/UI/Seller/src/app/shared/services/impersonation/impersonation.service.ts
+++ b/src/UI/Seller/src/app/shared/services/impersonation/impersonation.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, Inject } from '@angular/core'
-import { OcUserService, OcBuyerService } from '@ordercloud/angular-sdk'
+import { OcUserService, OcBuyerService, OcApiClientService } from '@ordercloud/angular-sdk'
 import { applicationConfiguration } from '@app-seller/config/app.config'
 import { AppConfig } from '@app-seller/models/environment.types'
+import { listAll } from '../listAll'
+import { ApiClients, ApiClientAssignment } from 'ordercloud-javascript-sdk'
 
 @Injectable({
   providedIn: 'root',
@@ -10,22 +12,25 @@ export class ImpersonationService {
   constructor(
     private userService: OcUserService,
     private buyerService: OcBuyerService,
+    private apiClientService: OcApiClientService,
     @Inject(applicationConfiguration) private appConfig: AppConfig
   ) {}
 
   async impersonateUser(networkID: string, user: any): Promise<void> {
     const buyer = await this.buyerService.Get(networkID).toPromise()
-    const buyerConfig = this.appConfig.buyerConfigs[buyer.Name]
+    if(!buyer?.xp?.URL || !buyer?.xp?.ClientID) {
+      throw new Error("Buyer not configured for impersonation")
+    }
     const userCustomRoles = this.getCustomRolesForBuyerUser(user)
     const auth = await this.userService
       .GetAccessToken(networkID, user.ID, {
-        ClientID: buyerConfig.clientID,
+        ClientID: buyer.xp.ClientID,
         Roles: this.appConfig.impersonatingBuyerScope,
         CustomRoles: userCustomRoles,
       })
       .toPromise()
     const url =
-      buyerConfig.buyerUrl + 'impersonation?token=' + auth.access_token
+      buyer.xp.URL + 'impersonation?token=' + auth.access_token
     window.open(url, '_blank')
   }
 


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Allow users to configure buyer impersonation on the buyer edit page. Once impersonation is set up (with buyer url and api client) admin users will be able to impersonate buyers

For Reference: [HDS-124](https://four51.atlassian.net/browse/HDS-JIRANUMBER) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
