### PR TITLE
HDS-144 allow Synchronous operations

### DIFF
--- a/src/Middleware/src/Headstart.API/Startup.cs
+++ b/src/Middleware/src/Headstart.API/Startup.cs
@@ -32,6 +32,7 @@ using System.Net;
 using Microsoft.OpenApi.Models;
 using OrderCloud.Catalyst;
 using OrderCloud.Common.Services;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 namespace Headstart.API
 {
@@ -87,6 +88,10 @@ namespace Headstart.API
             var smartyStreetsUsClient = new ClientBuilder(_settings.SmartyStreetSettings.AuthID, _settings.SmartyStreetSettings.AuthToken).BuildUsStreetApiClient();
 
             services
+                .Configure<KestrelServerOptions>(options =>
+                {
+                    options.AllowSynchronousIO = true;
+                })
                 .AddSingleton<ISimpleCache, LazyCacheService>() // Replace LazyCacheService with RedisService if you have multiple server instances.
                 .ConfigureServices()
                 .AddOrderCloudUserAuth<AppSettings>()


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description

Need to add setting to allow Synchronous operations that occur in the OcWebhookAuth from catalysts (
more info:
https://stackoverflow.com/questions/47735133/asp-net-core-synchronous-operations-are-disallowed-call-writeasync-or-set-all)

For Reference: [HDS-144](https://four51.atlassian.net/browse/HDS-144) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
