### PR TITLE
HDS-124 allow '/' or no '/' at end of url

### DIFF
--- a/src/UI/Seller/src/app/shared/services/impersonation/impersonation.service.ts
+++ b/src/UI/Seller/src/app/shared/services/impersonation/impersonation.service.ts
@@ -31,8 +31,9 @@ export class ImpersonationService {
         CustomRoles: userCustomRoles,
       })
       .toPromise()
-    const url =
-      Buyer.xp.URL + 'impersonation?token=' + auth.access_token
+    const url = Buyer.xp.URL[Buyer.xp.URL.length - 1] === '/' ?
+      Buyer.xp.URL + 'impersonation?token=' + auth.access_token :
+      Buyer.xp.URL + '/impersonation?token=' + auth.access_token 
     window.open(url, '_blank')
   }
 


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Allow users to enter in a buyer url that ends in a / or does not end in a /. Impersonation should work either way.

For Reference: [HDS-124](https://four51.atlassian.net/browse/HDS-124) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
