### PR TITLE
HDS-144 allow synchronous operations (IIS)

### DIFF
--- a/src/Middleware/src/Headstart.API/Startup.cs
+++ b/src/Middleware/src/Headstart.API/Startup.cs
@@ -92,6 +92,10 @@ namespace Headstart.API
                 {
                     options.AllowSynchronousIO = true;
                 })
+                .Configure<IISServerOptions>(options =>
+                {
+                    options.AllowSynchronousIO = true;
+                })
                 .AddSingleton<ISimpleCache, LazyCacheService>() // Replace LazyCacheService with RedisService if you have multiple server instances.
                 .ConfigureServices()
                 .AddOrderCloudUserAuth<AppSettings>()


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
We are still getting errors trying to get shipping rates in the deployed demo app. Previously I added code to allow synchronous operations (used in webhook authentication in Catalysts) for Kestrel. This update allowed the shipping rates integration event to work correctly locally. However we are still having this issue on the deployed test app.

I think we also need to allow this operation for IIS to resolve this issue on the deployed test app.
Resource: https://stackoverflow.com/questions/47735133/asp-net-core-synchronous-operations-are-disallowed-call-writeasync-or-set-all 

For Reference: [HDS-144](https://four51.atlassian.net/browse/HDS-144) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
