### PR TITLE
HDS-102 removing old sdk asset upload method

### DIFF
--- a/src/UI/Seller/src/app/kits/components/kits-edit/kits-edit.component.ts
+++ b/src/UI/Seller/src/app/kits/components/kits-edit/kits-edit.component.ts
@@ -450,7 +450,7 @@ export class KitsEditComponent implements OnInit {
       File: file.File,
       FileName: file.Filename,
     } as AssetUpload
-    const newAsset: Asset = await HeadStartSDK.Upload.UploadAsset(
+    const newAsset: Asset = await ContentManagementClient.Assets.Upload(
       asset,
       accessToken
     )

--- a/src/UI/Seller/src/app/orders/components/upload-shipments/upload-shipments.component.ts
+++ b/src/UI/Seller/src/app/orders/components/upload-shipments/upload-shipments.component.ts
@@ -133,7 +133,7 @@ export class UploadShipmentsComponent {
       File: file.File,
       FileName: file.Filename,
     } as AssetUpload
-    const newAsset: Asset = await HeadStartSDK.Upload.UploadAsset(
+    const newAsset: Asset = await ContentManagementClient.Assets.Upload(
       asset,
       accessToken
     )

--- a/src/UI/Seller/src/app/shared/components/account-content/account-content.component.ts
+++ b/src/UI/Seller/src/app/shared/components/account-content/account-content.component.ts
@@ -9,10 +9,10 @@ import { getPsHeight } from '@app-seller/shared/services/dom.helper'
 import { CurrentUserService } from '@app-seller/shared/services/current-user/current-user.service'
 import { applicationConfiguration } from '@app-seller/config/app.config'
 import { environment } from 'src/environments/environment.local'
-import { ListPage, MeUser } from '@ordercloud/angular-sdk'
+import { MeUser } from '@ordercloud/angular-sdk'
 import { FormGroup, FormControl } from '@angular/forms'
 import { isEqual as _isEqual, set as _set, get as _get } from 'lodash'
-import { HeadStartSDK, Asset, AssetUpload } from '@ordercloud/headstart-sdk'
+import { Asset, AssetUpload } from '@ordercloud/headstart-sdk'
 import { JDocument } from '@ordercloud/cms-sdk'
 import { AppAuthService } from '@app-seller/auth/services/app-auth.service'
 import { ContentManagementClient } from '@ordercloud/cms-sdk'
@@ -204,7 +204,7 @@ export abstract class AccountContent implements AfterViewChecked, OnInit {
       Tags: ['ProfileImg'],
     }
     // Upload the asset, then make the asset assignment to Suppliers
-    const newAsset: Asset = await HeadStartSDK.Upload.UploadAsset(
+    const newAsset: Asset = await ContentManagementClient.Assets.Upload(
       asset,
       accessToken
     )

--- a/src/UI/Seller/src/app/suppliers/components/suppliers/supplier-edit/supplier-edit.component.ts
+++ b/src/UI/Seller/src/app/suppliers/components/suppliers/supplier-edit/supplier-edit.component.ts
@@ -272,8 +272,7 @@ export class SupplierEditComponent implements OnInit, OnChanges {
       FileName: file.name,
       Tags: ['Logo'],
     }
-    // Upload the asset, then make the asset assignment to Suppliers
-    const newAsset: Asset = await HeadStartSDK.Upload.UploadAsset(
+    const newAsset: Asset = await ContentManagementClient.Assets.Upload(
       asset,
       accessToken
     )

--- a/src/UI/Seller/src/app/suppliers/components/suppliers/supplier-table/supplier-table.component.ts
+++ b/src/UI/Seller/src/app/suppliers/components/suppliers/supplier-table/supplier-table.component.ts
@@ -166,7 +166,7 @@ export class SupplierTableComponent extends ResourceCrudComponent<Supplier> {
           FileName: this.file.name,
           Tags: ['Logo'],
         }
-        const newAsset: Asset = await HeadStartSDK.Upload.UploadAsset(
+        const newAsset: Asset = await ContentManagementClient.Assets.Upload(
           asset,
           accessToken
         )

--- a/src/UI/Seller/src/web.config
+++ b/src/UI/Seller/src/web.config
@@ -20,7 +20,7 @@
         <add name="Cache-Control" value="no-cache, no-store"/>
         <add name="X-Content-Type-Options" value="nosniff" />
         <add name="Referrer-Policy" value="no-referrer-when-downgrade"/>
-        <add name="Content-Security-Policy" value="default-src 'self'; connect-src *; font-src *; frame-src *; img-src *; data: https; media-src *; object-src *; script-src * 'unsafe-inline' 'unsafe-eval'; style-src * 'unsafe-inline';" />
+        <add name="Content-Security-Policy" value="default-src 'self'; connect-src *; font-src *; frame-src *; img-src * 'self'; data: https; media-src *; object-src *; script-src * 'unsafe-inline' 'unsafe-eval'; style-src * 'unsafe-inline';" />
         <add name="Feature-Policy" value="accelerometer 'none'; ambient-light-sensor 'none'; animations *; autoplay *; camera 'none'; display-capture *; document-write *; encrypted-media *; fullscreen *; geolocation 'none'; gyroscope 'none'; image-compression *; layout-animations *; legacy-image-formats *; magnetometer 'none'; max-downscaling-image *; microphone 'none'; midi 'none'; oversized-images *; payment 'none'; picture-in-picture *; publickey-credentials 'none'; speaker *; sync-xhr *; unsized-media *; usb 'none'; vr 'none'; vertical-scroll *; wake-lock 'none';" />
       </customHeaders>
     </httpProtocol>


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Errors uploading assets due to remnants of old sdk left in codebase. This has been replaced with correct CMS api calls.

For Reference: [HDS-102](https://four51.atlassian.net/browse/HDS-102) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
