### PR TITLE
HDS-168 allow using only json file without having to load app config

### DIFF
--- a/src/Middleware/src/Headstart.API/Program.cs
+++ b/src/Middleware/src/Headstart.API/Program.cs
@@ -20,9 +20,11 @@ namespace Headstart.API
 				.UseDefaultServiceProvider(options => options.ValidateScopes = false)
 				.ConfigureAppConfiguration((context, config) =>
 				{
-					config
-						.AddAzureAppConfiguration(appConfigConnectionString, optional: true)
-						.AddJsonFile("appSettings.json", optional: true);
+					if(appConfigConnectionString != null)
+                    {
+						config.AddAzureAppConfiguration(appConfigConnectionString);
+					}
+					config.AddJsonFile("appSettings.json", optional: true);
 				})
 				.UseStartup<Startup>()
 				.ConfigureServices((ctx, services) =>

--- a/src/Middleware/src/Headstart.Common/AppSettings.cs
+++ b/src/Middleware/src/Headstart.Common/AppSettings.cs
@@ -11,8 +11,8 @@ namespace Headstart.Common
         public UI UI { get; set; }
         public EnvironmentSettings EnvironmentSettings { get; set; } = new EnvironmentSettings();
         public ApplicationInsightsSettings ApplicationInsightsSettings { get; set; } = new ApplicationInsightsSettings();
-        public AvalaraSettings AvalaraSettings { get; set; }
-        public BlobSettings BlobSettings { get; set; }
+        public AvalaraSettings AvalaraSettings { get; set; } = new AvalaraSettings();
+        public BlobSettings BlobSettings { get; set; } = new BlobSettings();
         public CosmosSettings CosmosSettings { get; set; } = new CosmosSettings();
         public OrderCloudSettings OrderCloudSettings { get; set; } = new OrderCloudSettings();
         public OrderCloudIntegrationsCardConnectConfig CardConnectSettings { get; set; } = new OrderCloudIntegrationsCardConnectConfig();


### PR DESCRIPTION
## Description
Sitecore team found that although you are able to override values by loading a JSON file there is still a requirement to load an azure app configuration otherwise it throws an error. This removes that requirement.


For Reference: [HDS-168 ](https://four51.atlassian.net/browse/HDS-168 ) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
