### PR TITLE
HDS-138: Remove specs/variants/varText specs when toggled off

### DIFF
--- a/src/UI/Seller/src/app/products/components/product-variations/product-variations.component.ts
+++ b/src/UI/Seller/src/app/products/components/product-variations/product-variations.component.ts
@@ -144,6 +144,19 @@ export class ProductVariations implements OnChanges {
   }
 
   toggleEditSpecs(): void {
+    if (this.editSpecs) {
+      const updateProductResourceCopy = this.productService.copyResource(
+        this.superProductEditable || this.productService.emptyResource
+      )
+      // Remove all specs that are *not* variable text specs
+      updateProductResourceCopy.Specs = updateProductResourceCopy.Specs.filter(
+        (s) => s.AllowOpenText
+      )
+      updateProductResourceCopy.Variants = []
+      this.superProductEditable = updateProductResourceCopy
+      this.checkForSpecChanges()
+      this.productVariationsChanged.emit(this.superProductEditable)
+    }
     this.editSpecs = !this.editSpecs
   }
 
@@ -231,6 +244,18 @@ export class ProductVariations implements OnChanges {
   }
 
   toggleAddVariableTextSpecs(event: any): void {
+    if (this.addVariableTextSpecs) {
+      const updateProductResourceCopy = this.productService.copyResource(
+        this.superProductEditable || this.productService.emptyResource
+      )
+      // Remove all specs that are variable text specs
+      updateProductResourceCopy.Specs = updateProductResourceCopy.Specs.filter(
+        (s) => !s.AllowOpenText
+      )
+      this.superProductEditable = updateProductResourceCopy
+      this.checkForSpecChanges()
+      this.productVariationsChanged.emit(this.superProductEditable)
+    }
     this.addVariableTextSpecs = event?.target?.checked
   }
 


### PR DESCRIPTION
## Description
When you toggle the options to 'turn off' either variable text specs, or standard specs/variants - they will now be removed, respectively.  

For Reference: [HDS-138](https://four51.atlassian.net/browse/HDS-138) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
