### PR TITLE
Seeding update

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/BuyerCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/BuyerCommand.cs
@@ -46,15 +46,19 @@ namespace Headstart.API.Commands
         {
             // to prevent changing buyerIDs
             superBuyer.Buyer.ID = buyerID;
+            var updatedImpersonationConfig = new ImpersonationConfig();
 
             var updatedBuyer = await _oc.Buyers.SaveAsync<HSBuyer>(buyerID, superBuyer.Buyer, token);
             var updatedMarkup = await UpdateMarkup(superBuyer.Markup, superBuyer.Buyer.ID, token);
-            var updatedImpersonation = await SaveImpersonationConfig(superBuyer.ImpersonationConfig, buyerID, token);
+            if(superBuyer.ImpersonationConfig != null)
+            {
+                updatedImpersonationConfig = await SaveImpersonationConfig(superBuyer.ImpersonationConfig, buyerID, token);
+            }
             return new SuperHSBuyer()
             {
                 Buyer = updatedBuyer,
                 Markup = updatedMarkup,
-                ImpersonationConfig = updatedImpersonation
+                ImpersonationConfig = updatedImpersonationConfig
             };
         }
 

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
@@ -234,8 +234,6 @@ namespace Headstart.API.Commands
                 $"{seed.AnonymousShoppingBuyerID}-{SeedConstants.DefaultLocationID}", 
                 SeedConstants.DefaultBuyerLocation(), token, true);
             Console.WriteLine(createBuyerLocation);
-            var test = await _oc.UserGroups.GetAsync(seed.AnonymousShoppingBuyerID, $"{seed.AnonymousShoppingBuyerID}-{SeedConstants.DefaultLocationID}");
-            Console.WriteLine(test);
 
 
             var assignment = new UserGroupAssignment()
@@ -243,7 +241,7 @@ namespace Headstart.API.Commands
                 UserGroupID = $"{seed.AnonymousShoppingBuyerID}-{SeedConstants.DefaultLocationID}",
                 UserID = anonBuyer.ID
             };
-            var saveAssignment = _oc.UserGroups.SaveUserAssignmentAsync(seed.AnonymousShoppingBuyerID, assignment, token);
+            var saveAssignment = _oc.UserGroups.SaveUserAssignmentAsync(seed.AnonymousShoppingBuyerID, assignment, accessToken: token);
             await createUser;
 
             await saveAssignment;

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
@@ -61,10 +61,6 @@ namespace Headstart.API.Commands
             {
                 throw new Exception("Missing required seeding field OrderCloudSettings:WebhookHashKey");
             }
-            //if (string.IsNullOrEmpty(seed.MiddlewareBaseUrl))
-            //{
-            //    throw new Exception("Missing required seeding field MiddlewareBaseUrl");
-            //}
 
             var portalUserToken = await _portal.Login(seed.PortalUsername, seed.PortalPassword);
             await VerifyOrgExists(seed.SellerOrgID, portalUserToken);

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
@@ -154,7 +154,7 @@ namespace Headstart.API.Commands
         #endregion
 
         #region IntegrationEvents
-        public static IntegrationEvent CheckoutEvent(AppSettings settings)
+        public static IntegrationEvent CheckoutEvent(string middlewareBaseUrl, string webhookHashKey)
         {
             return new IntegrationEvent()
             {
@@ -162,8 +162,8 @@ namespace Headstart.API.Commands
                 ID = "HeadStartCheckout",
                 EventType = IntegrationEventType.OrderCheckout,
                 Name = "HeadStart Checkout",
-                CustomImplementationUrl = settings.EnvironmentSettings.MiddlewareBaseUrl,
-                HashKey = settings.OrderCloudSettings.WebhookHashKey,
+                CustomImplementationUrl = middlewareBaseUrl,
+                HashKey = webhookHashKey,
                 ConfigData = new
                 {
                     ExcludePOProductsFromShipping = false,
@@ -172,7 +172,7 @@ namespace Headstart.API.Commands
             };
         }
 
-        public static IntegrationEvent LocalCheckoutEvent(AppSettings settings)
+        public static IntegrationEvent LocalCheckoutEvent(string webhookHashKey)
         {
             return new IntegrationEvent()
             {
@@ -181,7 +181,7 @@ namespace Headstart.API.Commands
                 EventType = IntegrationEventType.OrderCheckout,
                 CustomImplementationUrl = "https://marketplaceteam.ngrok.io", // local webhook url
                 Name = "HeadStart Checkout LOCAL",
-                HashKey = settings.OrderCloudSettings.WebhookHashKey,
+                HashKey = webhookHashKey,
                 ConfigData = new
                 {
                     ExcludePOProductsFromShipping = false,
@@ -192,7 +192,7 @@ namespace Headstart.API.Commands
         #endregion
 
         #region MessageSenders
-        public static MessageSender BuyerEmails(AppSettings settings)
+        public static MessageSender BuyerEmails(EnvironmentSeed seed)
         {
             return new MessageSender()
             {
@@ -209,12 +209,12 @@ namespace Headstart.API.Commands
                         // MessageType.OrderSubmittedForYourApprovalHasBeenDeclined, // too noisy
                         // MessageType.ShipmentCreated this is currently being triggered in-app possibly move to message senders
                     },
-                URL = settings.EnvironmentSettings.MiddlewareBaseUrl + "/messagesenders/{messagetype}",
-                SharedKey = settings.OrderCloudSettings.WebhookHashKey
+                URL = seed.MiddlewareBaseUrl + "/messagesenders/{messagetype}",
+                SharedKey = seed.OrderCloudSettings.WebhookHashKey
             };
         }
 
-        public static MessageSender SellerEmails(AppSettings settings)
+        public static MessageSender SellerEmails(EnvironmentSeed seed)
         {
             return new MessageSender()
             {
@@ -223,12 +223,12 @@ namespace Headstart.API.Commands
                 MessageTypes = new[] {
                         MessageType.ForgottenPassword,
                     },
-                URL = settings.EnvironmentSettings.MiddlewareBaseUrl + "/messagesenders/{messagetype}",
-                SharedKey = settings.OrderCloudSettings.WebhookHashKey
+                URL = seed.MiddlewareBaseUrl + "/messagesenders/{messagetype}",
+                SharedKey = seed.OrderCloudSettings.WebhookHashKey
             };
         }
 
-        public static MessageSender SuplierEmails(AppSettings settings)
+        public static MessageSender SuplierEmails(EnvironmentSeed seed)
         {
             return new MessageSender()
             {
@@ -237,8 +237,8 @@ namespace Headstart.API.Commands
                 MessageTypes = new[] {
                         MessageType.ForgottenPassword,
                     },
-                URL = settings.EnvironmentSettings.MiddlewareBaseUrl + "/messagesenders/{messagetype}",
-                SharedKey = settings.OrderCloudSettings.WebhookHashKey
+                URL = seed.MiddlewareBaseUrl + "/messagesenders/{messagetype}",
+                SharedKey = seed.OrderCloudSettings.WebhookHashKey
             };
         }
         #endregion
@@ -278,6 +278,12 @@ namespace Headstart.API.Commands
 			new HSSecurityProfile() { ID = CustomRole.HSLocationOrderApprover, CustomRoles = new CustomRole[] { CustomRole.HSLocationOrderApprover }, Roles = new ApiRole[] { } },
             new HSSecurityProfile() { ID = CustomRole.HSLocationViewAllOrders, CustomRoles = new CustomRole[] { CustomRole.HSLocationViewAllOrders }, Roles = new ApiRole[] { } },
             new HSSecurityProfile() { ID = CustomRole.HSLocationAddressAdmin, CustomRoles = new CustomRole[] { CustomRole.HSLocationAddressAdmin }, Roles = new ApiRole[] { } },
+            new HSSecurityProfile() { ID = CustomRole.HSLocationPermissionAdmin, CustomRoles = new CustomRole[] { CustomRole.HSLocationPermissionAdmin }, Roles = new ApiRole[] { } },
+            new HSSecurityProfile() { ID = CustomRole.HSLocationNeedsApproval, CustomRoles = new CustomRole[] { CustomRole.HSLocationNeedsApproval }, Roles = new ApiRole[] { } },
+            new HSSecurityProfile() { ID = CustomRole.HSLocationCreditCardAdmin, CustomRoles = new CustomRole[] { CustomRole.HSLocationCreditCardAdmin }, Roles = new ApiRole[] { } },
+            new HSSecurityProfile() { ID = CustomRole.HSLocationResaleCertAdmin, CustomRoles = new CustomRole[] { CustomRole.HSLocationResaleCertAdmin }, Roles = new ApiRole[] { } },
+
+
         };
 
         public static readonly List<CustomRole> SellerHsRoles = new List<CustomRole>() {

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -39,11 +39,12 @@ namespace Headstart.Models.Misc
 		public string InitialAdminPassword { get; set; }
 
 		/// <summary>
-		/// The ID of the seller organization to be seeded
-		/// it is not currently possible to create an organization outside of the portal
+		/// Optionally pass in a value if you have an existing organization you would like to seed. If no value is present a new org will be created
+		/// Creating an org via seeding is only possible in the sandbox api environment
 		/// </summary>
-		[Required]
 		public string SellerOrgID { get; set; }
+
+		public string SellerOrgName { get; set; }
 
 		/// <summary>
 		/// An optional array of suppliers to create as part of the initial seeding
@@ -62,7 +63,7 @@ namespace Headstart.Models.Misc
 		public string AnonymousShoppingBuyerID { get; set; }
 
 		public string MiddlewareBaseUrl { get; set; }
-        public OrderCloudSettings OrderCloudSettings { get; set; }
+        public OrderCloudSeedRequest OrderCloudSettings { get; set; }
 		public BlobSettings BlobSettings { get; set; }
     }
 
@@ -70,6 +71,34 @@ namespace Headstart.Models.Misc
 	public class EnvironmentSeedResponse
     {
 		public string Comments { get; set; }
+		public string OrganizationName { get; set; }
+		public string OrganizationID { get; set; }
+		public string OrderCloudEnvironment { get; set; }
 		public Dictionary<string, dynamic> ApiClients { get; set; }
+    }
+
+	public class OrderCloudSeedRequest : OrderCloudSettings
+	{
+		public string Environment { get; set; }
+	}
+
+	public class OrderCloudEnvironments
+    {
+		public static OcEnv Production = new OcEnv()
+		{
+			environmentName = "Production",
+			apiUrl = "https://api.ordercloud.io"
+		};
+		public static OcEnv Sandbox = new OcEnv()
+		{
+			environmentName = "Sandbox",
+			apiUrl = "https://sandboxapi.ordercloud.io"
+		};
+    }
+
+	public class OcEnv
+    {
+        public string environmentName { get; set; }
+		public string apiUrl { get; set; }
     }
 }

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -5,6 +5,7 @@ using SendGrid.Helpers.Mail;
 using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 using Headstart.Models.Headstart;
+using Headstart.Common;
 
 namespace Headstart.Models.Misc
 {
@@ -59,7 +60,11 @@ namespace Headstart.Models.Misc
 		/// Otherwise we will assign the default buyer that is created in seeding.
 		/// </summary>
 		public string AnonymousShoppingBuyerID { get; set; }
-	}
+
+		public string MiddlewareBaseUrl { get; set; }
+        public OrderCloudSettings OrderCloudSettings { get; set; }
+		public BlobSettings BlobSettings { get; set; }
+    }
 
 	[DocIgnore]
 	public class EnvironmentSeedResponse

--- a/src/Middleware/src/Headstart.Common/Services/Portal/PortalService.cs
+++ b/src/Middleware/src/Headstart.Common/Services/Portal/PortalService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Flurl.Http;
 using Flurl.Http.Configuration;
@@ -78,8 +78,9 @@ namespace Headstart.Common.Services
 
         public async Task CreateOrganization(Organization org, string token)
         {
-            // doesn't return anything
-            await _client.Request("organizations", token)
+            //  doesn't return anything
+            await _client.Request($"organizations/{org.Id}")
+                .WithOAuthBearerToken(token)
                 .PutJsonAsync(org);
         }
     }

--- a/src/UI/Seller/src/assets/appConfigs/README.md
+++ b/src/UI/Seller/src/assets/appConfigs/README.md
@@ -11,6 +11,6 @@ You can have any number of configurations each representing a deployment. By def
 | cmsUrl                        | The base url to the hosted CMS URL by OrderCloud (non-official)                                                                                  |
 | translateBlobUrl              | The base url to the folder including your translations. See https://github.com/ngx-translate/core for more info                                  |
 | blobStorageUrl                | the base url to the blob storage account                                                                                                         |
-| orderCloudApiUrl              | The base url to the OrderCloud API. Can be one of: https://api.ordercloud.io, https://sandbox.ordercloud.io, https://staging.ordercloud.io       |
+| orderCloudApiUrl              | The base url to the OrderCloud API. Can be one of: https://api.ordercloud.io, https://sandboxapi.ordercloud.io, https://stagingapi.ordercloud.io       |
 | buyerConfigs                  | A dictionary where each key represents a new buyer and details about that buyer such as clientID and buyerURl used for impersonation             |
 | superProductFieldsToMonitor   | Fields to monitor for changes. Until approved by seller product will not be purchasable                                                          |


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
1. Updated seeding function so it only uses data from request body. Users do not have to have an appsettings set up to seed their org. 
2. Allowed users to seed an org without providing a sellerOrgID. In this case we create the org for them.
3. Added some validation around making sure users enter correct environment and don't try and create prod orgs.
4. Updated response data.

For Reference: [HDS-187](https://four51.atlassian.net/browse/HDS-187) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
