### PR TITLE
HDS-193: Add xp.BuyersServicing to env seed

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
@@ -72,6 +72,7 @@ namespace Headstart.API.Commands
             new XpIndex { ThingType = XpThingType.Company, Key = "Data.ServiceCategory" },
             new XpIndex { ThingType = XpThingType.Company, Key = "Data.VendorLevel" },
             new XpIndex { ThingType = XpThingType.Company, Key = "SyncFreightPop" },
+            new XpIndex { ThingType = XpThingType.Company, Key = "BuyersServicing" },
             new XpIndex { ThingType = XpThingType.Company, Key = "CountriesServicing" },
             new XpIndex { ThingType = XpThingType.Order, Key = "NeedsAttention" },
             new XpIndex { ThingType = XpThingType.Order, Key = "StopShipSync" },


### PR DESCRIPTION
## Description
- The environment seed was missing an xp index for xp.BuyersServicing causing issues in the supplier list page of the buyer app

For Reference: [HDS-193](https://four51.atlassian.net/browse/HDS-193) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
