### PR TITLE
HDS-167 use Guid and make sure cannot overwrite org

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
@@ -179,22 +179,20 @@ namespace Headstart.API.Commands
             {
                 var org = new Organization()
                 {
-                    Id = RandomString(10),
+                    Id = Guid.NewGuid().ToString(),
                     Environment = env,
                     Name = orgName == null ? "My Headstart Organization" : orgName
-
                 };
-                await _portal.CreateOrganization(org, token);
-                return await _portal.GetOrganization(org.Id, token);
+                try
+                {
+                    await _portal.GetOrganization(org.Id, token);
+                    return await GetOrCreateOrg(token, env, orgName, orgID);
+                } catch (Exception ex)
+                {
+                    await _portal.CreateOrganization(org, token);
+                    return await _portal.GetOrganization(org.Id, token);
+                }
             }
-        }
-
-        private static Random random = new Random();
-        public static string RandomString(int length)
-        {
-         const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-            return new string(Enumerable.Repeat(chars, length)
-              .Select(s => s[random.Next(s.Length)]).ToArray());
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Use Guid for generating an org ID. Also add try/catch where we first try to get an org to prevent potentially overwriting.

For Reference: [HDS-167](https://four51.atlassian.net/browse/HDS-167) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
