### PR TITLE
HDS-151 handle assigning user to permission group if DNE

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
@@ -15,6 +15,7 @@ namespace Headstart.API.Commands
         Task<HSBuyerLocation> Get(string buyerID, string buyerLocationID, string token);
         Task<HSBuyerLocation> Save(string buyerID, string buyerLocationID, HSBuyerLocation buyerLocation, string token, bool isSeedEnv = false);
         Task Delete(string buyerID, string buyerLocationID, string token);
+        Task CreateSinglePermissionGroup(string token, string buyerLocationID, string permissionGroupID);
     }
 
     public class HSBuyerLocationCommand : IHSBuyerLocationCommand
@@ -135,6 +136,12 @@ namespace Headstart.API.Commands
                     RuleExpression = $"order.xp.ApprovalNeeded = '{buyerLocationID}' & order.Total > 0"
                 });
             }
+        }
+
+        public async Task CreateSinglePermissionGroup(string token, string buyerLocationID, string permissionGroupID)
+        {
+            var permissionGroup = HSUserTypes.BuyerLocation().Find(userType => permissionGroupID.Contains(userType.UserGroupIDSuffix));
+            await AddUserTypeToLocation(token, buyerLocationID, permissionGroup);
         }
 
         public async Task AddUserTypeToLocation(string token, string buyerLocationID, HSUserType hsUserType)

--- a/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
@@ -42,6 +42,14 @@ namespace Headstart.Common.Controllers
             return await _buyerLocationCommand.Create(buyerID, buyerLocation, ocAuth.AccessToken);
         }
 
+        [DocName("POST a Buyer Location permission group")]
+        [HttpPost, Route("{buyerID}/{buyerLocationID}/permissions/{permissionGroupID}"), OrderCloudUserAuth(ApiRole.UserGroupAdmin, ApiRole.AddressAdmin)]
+        public async Task CreatePermissionGroup(string buyerID, string buyerLocationID, string permissionGroupID)
+        {
+            var ocAuth = await _oc.AuthenticateAsync();
+            await _buyerLocationCommand.CreateSinglePermissionGroup(ocAuth.AccessToken, buyerLocationID, permissionGroupID);
+        }
+
         [DocName("PUT a Buyer Location")]
         [HttpPut, Route("{buyerID}/{buyerLocationID}"), OrderCloudUserAuth(ApiRole.UserGroupAdmin, ApiRole.AddressAdmin)]
         public async Task<HSBuyerLocation> Save(string buyerID, string buyerLocationID, [FromBody] HSBuyerLocation buyerLocation)

--- a/src/UI/Seller/src/app/buyers/components/locations/buyer-location-permissions/buyer-location-permissions.constants.ts
+++ b/src/UI/Seller/src/app/buyers/components/locations/buyer-location-permissions/buyer-location-permissions.constants.ts
@@ -1,3 +1,5 @@
+import { PermissionType } from "@app-seller/shared"
+
 export const UserGroupTypes = {
   UserPermissions: 'UserPermissions',
   BuyerLocation: 'BuyerLocation',
@@ -22,3 +24,14 @@ const MapToUserGroupDisplayText = {
 export const GetDisplayText = (userGroupType: string): string => {
   return MapToUserGroupDisplayText[userGroupType]
 }
+
+export const PermissionTypes: PermissionType[] = [
+  { UserGroupSuffix: 'PermissionAdmin', DisplayText: 'Permission Admin' },
+  { UserGroupSuffix: 'ResaleCertAdmin', DisplayText: 'Resale Cert Admin' },
+  { UserGroupSuffix: 'OrderApprover', DisplayText: 'Order Approver' },
+  { UserGroupSuffix: 'NeedsApproval', DisplayText: 'Needs Approval' },
+  { UserGroupSuffix: 'ViewAllOrders', DisplayText: 'View All Orders' },
+  { UserGroupSuffix: 'CreditCardAdmin', DisplayText: 'Credit Card Admin' },
+  { UserGroupSuffix: 'AddressAdmin', DisplayText: 'Address Admin' },
+]
+

--- a/src/UI/Seller/src/app/buyers/components/locations/buyer-location-permissions/buyer-location-permissions.ts
+++ b/src/UI/Seller/src/app/buyers/components/locations/buyer-location-permissions/buyer-location-permissions.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core'
 import { UserGroupAssignment, User } from '@ordercloud/angular-sdk'
 import { BuyerLocationService } from '../buyer-location.service'
 import { REDIRECT_TO_FIRST_PARENT } from '@app-seller/layout/header/header.config'
-import { PermissionTypes } from '../buyer-location.service'
+import { PermissionTypes } from '../buyer-location-permissions/buyer-location-permissions.constants'
 import { BuyerUserService } from '../../users/buyer-user.service'
 import { PermissionType } from '@app-seller/models/user.types'
 
@@ -110,8 +110,8 @@ export class BuyerLocationPermissions {
 
   async executeUserUserGroupAssignmentRequests(): Promise<void> {
     this.requestedUserConfirmation = false
-    await this.buyerUserService.updateUserUserGroupAssignments(
-      this._locationID.split('-')[0],
+    await this.buyerUserService.updateBuyerPermissionGroupAssignments(
+      this._locationID,
       this.add,
       this.del
     )

--- a/src/UI/Seller/src/app/buyers/components/locations/buyer-location.service.ts
+++ b/src/UI/Seller/src/app/buyers/components/locations/buyer-location.service.ts
@@ -13,18 +13,9 @@ import { HeadStartSDK } from '@ordercloud/headstart-sdk'
 import { BuyerUserService } from '../users/buyer-user.service'
 import { CurrentUserService } from '@app-seller/shared/services/current-user/current-user.service'
 import { Addresses } from 'ordercloud-javascript-sdk'
-import { PermissionType } from '@app-seller/models/user.types'
+import { PermissionTypes } from './buyer-location-permissions/buyer-location-permissions.constants'
 
 
-export const PermissionTypes: PermissionType[] = [
-  { UserGroupSuffix: 'PermissionAdmin', DisplayText: 'Permission Admin' },
-  { UserGroupSuffix: 'ResaleCertAdmin', DisplayText: 'Resale Cert Admin' },
-  { UserGroupSuffix: 'OrderApprover', DisplayText: 'Order Approver' },
-  { UserGroupSuffix: 'NeedsApproval', DisplayText: 'Needs Approval' },
-  { UserGroupSuffix: 'ViewAllOrders', DisplayText: 'View All Orders' },
-  { UserGroupSuffix: 'CreditCardAdmin', DisplayText: 'Credit Card Admin' },
-  { UserGroupSuffix: 'AddressAdmin', DisplayText: 'Address Admin' },
-]
 
 // TODO - this service is only relevent if you're already on the supplier details page. How can we enforce/inidcate that?
 @Injectable({

--- a/src/UI/Seller/src/app/shared/services/middleware-api/buyer-temp.service.ts
+++ b/src/UI/Seller/src/app/shared/services/middleware-api/buyer-temp.service.ts
@@ -4,7 +4,6 @@ import { applicationConfiguration } from '@app-seller/config/app.config'
 import { HSBuyerPriceMarkup } from '@app-seller/models/buyer-markups.types'
 import { AppConfig } from '@app-seller/models/environment.types'
 import { OcTokenService } from '@ordercloud/angular-sdk'
-import { HSBuyer } from '@ordercloud/headstart-sdk'
 
 // WHOPLE FILE TO BE REPLACED BY SDK
 
@@ -50,5 +49,10 @@ export class BuyerTempService {
         headers: this.buildHeaders(),
       })
       .toPromise()
+  }
+
+  async createPermissionGroup(buyerID: string, buyerLocationID: string, permissionGroupID: string): Promise<any> {
+    const url = `${this.appConfig.middlewareUrl}/buyerlocations/${buyerID}/${buyerLocationID}/permissions/${permissionGroupID}`
+    return await this.http.post(url, {headers: this.buildHeaders()}).toPromise()
   }
 }


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
This PR handles situations where an admin user is attempting to assign a user to a permission group (OC usergroup) and that permission group does not exist.
1. Catch block that calls route to create that permission group and assign the correct security profile.
2. Retry assigning that group to specified user.

For Reference: [HDS-151](https://four51.atlassian.net/browse/151) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
