### PR TITLE
HDS-208: Ensure 'no results' msg displays properly

### DIFF
--- a/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.html
+++ b/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.html
@@ -246,7 +246,7 @@
                     </button>
                     <p
                       class="mb-0"
-                      *ngIf="!products?.length"
+                      *ngIf="!products?.value?.length && searchTerm"
                       ngbDropdownItem
                       disabled
                     >


### PR DESCRIPTION
## Description
- Fix the logic to target proper data point on observable to ensure 'no results for your search' message only shows when appropriate.

For Reference: [HDS-208](https://four51.atlassian.net/browse/HDS-208) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
