### PR TITLE
HDS-209: Shipping changes for HeadStart

### DIFF
--- a/src/Middleware/src/Headstart.Common/Extensions/ShipEstimatesExtensions.cs
+++ b/src/Middleware/src/Headstart.Common/Extensions/ShipEstimatesExtensions.cs
@@ -1,0 +1,139 @@
+using Headstart.Common.Constants;
+using Headstart.Common.Services.ShippingIntegration.Models;
+using Headstart.Models.Headstart;
+using ordercloud.integrations.exchangerates;
+using OrderCloud.SDK;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Headstart.Common.Extensions
+{
+    public static class ShipEstimatesExtensions
+    {
+        public static IList<HSShipEstimate> CheckForEmptyRates(this IList<HSShipEstimate> estimates, decimal noRatesCost, int noRatesTransitDays)
+        {
+            // if there are no rates for a set of line items then return a mocked response so user can check out
+            // this order will additionally get marked as needing attention
+
+            foreach (var shipEstimate in estimates)
+            {
+                if (!shipEstimate.ShipMethods.Any())
+                {
+                    shipEstimate.ShipMethods = new List<HSShipMethod>()
+                    {
+                        new HSShipMethod
+                        {
+                            ID = ShippingConstants.NoRatesID,
+                            Name = "No shipping rates",
+                            Cost = noRatesCost,
+                            EstimatedTransitDays = noRatesTransitDays,
+                            xp = new ShipMethodXP
+                            {
+                                OriginalCost = noRatesCost
+                            }
+                        }
+                    };
+                }
+            }
+            return estimates;
+        }
+
+        public static async Task<IList<HSShipEstimate>> ApplyShippingLogic(this IList<HSShipEstimate> shipEstimates, HSOrderWorksheet orderWorksheet, IOrderCloudClient _oc, int freeShippingTransitDays)
+        {
+            var updatedEstimates = new List<HSShipEstimate>();
+            var supplierIDs = orderWorksheet.LineItems.Select(li => li.SupplierID);
+            var suppliers = await _oc.Suppliers.ListAsync<HSSupplier>(filters: $"ID={string.Join("|", supplierIDs)}");
+            
+            foreach (var shipEstimate in shipEstimates)
+            {
+                var supplierID = orderWorksheet.LineItems.FirstOrDefault(li => li.ID == shipEstimate.ShipEstimateItems.FirstOrDefault()?.LineItemID)?.SupplierID;
+                var supplier = suppliers.Items.FirstOrDefault(s => s.ID == supplierID);
+                var supplierLineItems = orderWorksheet.GetBuyerLineItemsBySupplierID(supplier?.ID);
+                var supplierSubTotal = supplierLineItems?.Select(li => li.LineSubtotal).Sum();
+                // TODO: Still waiting on decision makers to decide if we want
+                // Shipping Cost Schedules in HeadStart
+
+                //var validCostBreaks = supplier?.xp?.ShippingCostSchedule?.CostBreaks?.Where(costBreak => costBreak.OrderSubTotal < supplierSubTotal);
+
+                // Update Free Shipping Rates
+                if (shipEstimate.ID.StartsWith(ShippingConstants.FreeShippingID))
+                {
+                    foreach (var method in shipEstimate.ShipMethods)
+                    {
+                        method.ID = shipEstimate.ID;
+                        method.Cost = 0;
+                        method.EstimatedTransitDays = freeShippingTransitDays;
+                    }
+                }
+
+                foreach (var method in shipEstimate.ShipMethods)
+                {
+                    // Apply Free Shipping on orders where we weren't able to calculate a shipping rate
+                    if (method.ID == ShippingConstants.NoRatesID)
+                    {
+                        method.xp.FreeShippingApplied = true;
+                        method.xp.FreeShippingThreshold = supplier.xp.FreeShippingThreshold;
+                        method.Cost = 0;
+                    }
+                    // TODO: Still waiting on decision makers to decide if we want
+                    // Shipping Cost Schedules in HeadStart
+
+                    // If valid Cost Breaks exist, apply them
+                    //if (validCostBreaks != null)
+                    //{
+                    //    // Apply the Supplier Shipping Cost Schedule to Ground Rates only
+                    //    if (method.Name.Contains("GROUND"))
+                    //    {
+                    //        validCostBreaks = validCostBreaks.Where(cb => cb.ValidCountries.Contains(orderWorksheet?.Order?.FromUser?.xp?.Country));
+                    //        if (validCostBreaks != null && validCostBreaks.Count() > 0)
+                    //        {
+                    //            var sortedValidCostBreaks = validCostBreaks.OrderBy(costBreak => costBreak.OrderSubTotal);
+                    //            method.xp.ShippingCostScheduleOrderSubTotalThreshold = sortedValidCostBreaks.LastOrDefault().OrderSubTotal;
+                    //            method.xp.ShippingCostScheduleApplied = true;
+                    //            method.Cost = sortedValidCostBreaks.LastOrDefault().Cost;
+                    //            if (method.Cost == 0) // If cost = 0, then shipping is considered free
+                    //            {
+                    //                method.xp.FreeShippingApplied = true;
+                    //            }
+                    //        }
+                    //    }
+                    //}
+                }
+                updatedEstimates.Add(shipEstimate);
+            }
+
+            // Filter out any rates that are _not_ Fedex Ground, Fedex 2 day, and Fedex Standard Overnight
+            updatedEstimates = shipEstimates.Select(estimate => FilterDownFedexShippingRates(estimate)).ToList();
+            return updatedEstimates;
+        }
+        public static async Task<IList<HSShipEstimate>> ConvertCurrency(this IList<HSShipEstimate> shipEstimates, CurrencySymbol shipperCurrency, CurrencySymbol buyerCurrency, IExchangeRatesCommand _exchangeRates)
+        {
+            // If the Buyer's currency is USD, do not convert rates.
+            if (buyerCurrency == CurrencySymbol.USD) { return shipEstimates; };
+
+            var rates = (await _exchangeRates.Get(buyerCurrency)).Rates;
+            var conversionRate = rates.Find(r => r.Currency == shipperCurrency).Rate;
+            return shipEstimates.Select(estimate =>
+            {
+                estimate.ShipMethods = estimate.ShipMethods.Select(method =>
+                {
+                    method.xp.OriginalCurrency = shipperCurrency;
+                    method.xp.OrderCurrency = buyerCurrency;
+                    method.xp.ExchangeRate = conversionRate;
+                    if (conversionRate != null) method.Cost /= (decimal)conversionRate;
+                    return method;
+                }).ToList();
+                return estimate;
+            }).ToList();
+        }
+
+        #region Helper Methods
+        public static HSShipEstimate FilterDownFedexShippingRates(HSShipEstimate estimate)
+        {
+            estimate.ShipMethods = estimate.ShipMethods.Where(method => (method.ID != null && method.ID.Contains("FREE_SHIPPING")) || method?.ID == ShippingConstants.NoRatesID || method?.xp?.Carrier == "USPS" || method.Name == "FEDEX_GROUND" || method.Name == "FEDEX_2_DAY" || method.Name == "STANDARD_OVERNIGHT").ToList();
+            return estimate;
+        }
+        #endregion
+    }
+}

--- a/src/Middleware/tests/Headstart.Tests/CheckoutIntegrationCommandTests.cs
+++ b/src/Middleware/tests/Headstart.Tests/CheckoutIntegrationCommandTests.cs
@@ -9,190 +9,57 @@ using Headstart.Common.Services.ShippingIntegration.Models;
 using Headstart.Models.Headstart;
 using System.Linq;
 using Headstart.API.Commands;
+using Headstart.Common.Extensions;
+using Headstart.Tests.Mocks;
+using Headstart.Models;
 
 namespace Headstart.Tests
 {
     public class CheckoutIntegrationCommandTests
     {
-        #region FilterSlowerRatesWithHighCost
-        [Test]
-        public void dont_filter_valid_rates()
+        private IOrderCloudClient _oc;
+
+        [SetUp]
+        public void Setup()
         {
-            // preserve order, rates are already correct
+            _oc = Substitute.For<IOrderCloudClient>();
+            _oc.Suppliers.ListAsync<HSSupplier>().ReturnsForAnyArgs(SupplierMocks.SupplierList(MockSupplier("010"), MockSupplier("012"), MockSupplier("027"), MockSupplier("100")));
+        }
+
+        public const int FREE_SHIPPING_DAYS = 3;
+
+        #region CheckoutIntegrationTests
+        [Test]
+        public async Task free_shipping_for_no_rates()
+        {
+            var shipItem1 = new ShipEstimateItem
+            {
+                LineItemID = "Line1"
+            };
+            var line1 = new HSLineItem
+            {
+                ID = "Line1",
+                LineSubtotal = 370,
+                SupplierID = "010"
+            };
             var method1 = new HSShipMethod
             {
-                EstimatedTransitDays = 1,
-                Cost = 25
+                ID = "NO_SHIPPING_RATES",
+                xp = new ShipMethodXP()
             };
-            var method2 = new HSShipMethod
-            {
-                EstimatedTransitDays = 2,
-                Cost = 15
-            };
-            var method3 = new HSShipMethod
-            {
-                EstimatedTransitDays = 3,
-                Cost = 5
-            };
-            var estimates = BuildEstimates(new[] { method1, method2, method3 });
-            var result = CheckoutIntegrationCommand.FilterSlowerRatesWithHighCost(estimates);
+            var worksheet = BuildOrderWorksheet(new HSLineItem[] { line1 });
+            var estimates = BuildEstimates(new[] { method1 }, new[] { shipItem1 });
+            var result = await estimates.ApplyShippingLogic(worksheet, _oc, FREE_SHIPPING_DAYS);
             var methods = result[0].ShipMethods;
 
-            Assert.AreEqual(3, methods.Count);
-            Assert.AreEqual(25, methods[0].Cost);
-            Assert.AreEqual(15, methods[1].Cost);
-            Assert.AreEqual(5, methods[2].Cost);
+            Assert.AreEqual(1, methods.Count());
+            Assert.AreEqual(0, methods[0].Cost);
+            Assert.AreEqual(method1.Name, methods[0].Name);
+            Assert.IsTrue(methods[0].xp.FreeShippingApplied);
         }
 
         [Test]
-        public void remove_invalid_method()
-        {
-            // remove one offending ship method
-            var method1 = new HSShipMethod
-            {
-                EstimatedTransitDays = 1,
-                Cost = 10
-            };
-            var method2 = new HSShipMethod
-            {
-                EstimatedTransitDays = 2,
-                Cost = 5
-            };
-            var method3 = new HSShipMethod
-            {
-                EstimatedTransitDays = 3,
-                Cost = 20
-            };
-            var estimates = BuildEstimates(new[] { method1, method2, method3 });
-            var result = CheckoutIntegrationCommand.FilterSlowerRatesWithHighCost(estimates);
-            var methods = result[0].ShipMethods;
-
-            Assert.AreEqual(2, methods.Count);
-            Assert.AreEqual(10, methods[0].Cost);
-            Assert.AreEqual(5, methods[1].Cost);
-        }
-
-        [Test]
-        public void remove_two_invalid_methods()
-        {
-            // remove two offending ship methods
-            var method1 = new HSShipMethod
-            {
-                EstimatedTransitDays = 1,
-                Cost = 5
-            };
-            var method2 = new HSShipMethod
-            {
-                EstimatedTransitDays = 2,
-                Cost = 10
-            };
-            var method3 = new HSShipMethod
-            {
-                EstimatedTransitDays = 3,
-                Cost = 15
-            };
-            var estimates = BuildEstimates(new[] { method1, method2, method3 });
-            var result = CheckoutIntegrationCommand.FilterSlowerRatesWithHighCost(estimates);
-            var methods = result[0].ShipMethods;
-
-            Assert.AreEqual(1, methods.Count);
-            Assert.AreEqual(5, methods[0].Cost);
-        }
-
-        [Test]
-        public void handle_mixed_order_by_transit_days()
-        {
-            // remove two offending ship methods, transit days ordered backwards
-            var method1 = new HSShipMethod
-            {
-                EstimatedTransitDays = 3,
-                Cost = 15
-            };
-            var method2 = new HSShipMethod
-            {
-                EstimatedTransitDays = 2,
-                Cost = 10
-            };
-            var method3 = new HSShipMethod
-            {
-                EstimatedTransitDays = 1,
-                Cost = 5
-            };
-            var estimates = BuildEstimates(new[] { method1, method2, method3 });
-            var result = CheckoutIntegrationCommand.FilterSlowerRatesWithHighCost(estimates);
-            var methods = result[0].ShipMethods;
-
-            Assert.AreEqual(1, methods.Count);
-            Assert.AreEqual(5, methods[0].Cost);
-        }
-
-        [Test]
-        public void handle_free_shipping()
-        {
-            // handle free shipping
-            var method1 = new HSShipMethod
-            {
-                EstimatedTransitDays = 1,
-                Cost = 15
-            };
-            var method2 = new HSShipMethod
-            {
-                EstimatedTransitDays = 2,
-                Cost = 0
-            };
-            var method3 = new HSShipMethod
-            {
-                EstimatedTransitDays = 3,
-                Cost = 5
-            };
-            var estimates = BuildEstimates(new[] { method1, method2, method3 });
-            var result = CheckoutIntegrationCommand.FilterSlowerRatesWithHighCost(estimates);
-            var methods = result[0].ShipMethods;
-
-            Assert.AreEqual(2, methods.Count);
-            Assert.AreEqual(15, methods[0].Cost);
-            Assert.AreEqual(0, methods[1].Cost);
-        }
-
-        [Test]
-        public void handle_methods_with_same_rates()
-        {
-            // handle two estimates with same rates
-            // we do not want to filter out a slower estimate with the same rate
-            var method1 = new HSShipMethod
-            {
-                EstimatedTransitDays = 1,
-                Cost = 15
-            };
-            var method2 = new HSShipMethod
-            {
-                EstimatedTransitDays = 2,
-                Cost = 15
-            };
-            var method3 = new HSShipMethod
-            {
-                EstimatedTransitDays = 3,
-                Cost = 5
-            };
-            var estimates = BuildEstimates(new[] { method1, method2, method3 });
-            var result = CheckoutIntegrationCommand.FilterSlowerRatesWithHighCost(estimates);
-            var methods = result[0].ShipMethods;
-
-            Assert.AreEqual(3, methods.Count);
-            Assert.AreEqual(15, methods[0].Cost);
-            Assert.AreEqual(1, methods[0].EstimatedTransitDays);
-            Assert.AreEqual(5, methods[2].Cost);
-            Assert.AreEqual(3, methods[2].EstimatedTransitDays);
-        }
-
-
-        #endregion
-        #region ApplyFlatRateShipping
-        public const decimal FLAT_RATE_FIRST_TIER = 29.99M;
-        public const decimal FLAT_RATE_SECOND_TIER = 0;
-
-        [Test]
-        public void flatrateshipping_ignore_nonground()
+        public async Task shipping_ignore_nongroundAsync()
         {
             // don't transform methods if they aren't ground
             var shipItem1 = new ShipEstimateItem
@@ -207,14 +74,14 @@ namespace Headstart.Tests
             };
             var method1 = new HSShipMethod
             {
-                Name = "PRIORITY_OVERNIGHT",
+                Name = "STANDARD_OVERNIGHT",
                 EstimatedTransitDays = 1,
                 Cost = 150,
                 xp = new ShipMethodXP { }
             };
-            var worksheet = BuildOrderWorksheet(line1);
+            var worksheet = BuildOrderWorksheet(new HSLineItem[] { line1 });
             var estimates = BuildEstimates(new[] { method1 }, new[] { shipItem1 });
-            var result = ApplyFlatRateShipping(worksheet, estimates, "027", null);
+            var result = await estimates.ApplyShippingLogic(worksheet, _oc, FREE_SHIPPING_DAYS);
             var methods = result[0].ShipMethods;
 
             Assert.AreEqual(1, methods.Count());
@@ -223,7 +90,7 @@ namespace Headstart.Tests
         }
 
         [Test]
-        public void flatrateshipping_ignore_zerocost()
+        public async Task shipping_ignore_zerocostAsync()
         {
             // don't transform methods if they are zero cost
             var shipItem1 = new ShipEstimateItem
@@ -243,9 +110,9 @@ namespace Headstart.Tests
                 Cost = 60,
                 xp = new ShipMethodXP { }
             };
-            var worksheet = BuildOrderWorksheet(line1);
+            var worksheet = BuildOrderWorksheet(new HSLineItem[] { line1 });
             var estimates = BuildEstimates(new[] { method1 }, new[] { shipItem1 });
-            var result = ApplyFlatRateShipping(worksheet, estimates, "027", null);
+            var result = await estimates.ApplyShippingLogic(worksheet, _oc, FREE_SHIPPING_DAYS);
             var methods = result[0].ShipMethods;
 
             Assert.AreEqual(1, methods.Count());
@@ -253,340 +120,50 @@ namespace Headstart.Tests
             Assert.AreEqual(method1.Name, methods[0].Name);
         }
 
-        [Test]
-        public void flatrateshipping_handle_first_tier()
-        {
-            // set shipping cost to $29.99 if line item cost is between 0.01$ and $499.99
-            var shipItem1 = new ShipEstimateItem
-            {
-                LineItemID = "Line1"
-            };
-            var line1 = new HSLineItem
-            {
-                ID = "Line1",
-                LineSubtotal = 370,
-                SupplierID = "027"
-            };
-            var method1 = new HSShipMethod
-            {
-                Name = "FEDEX_GROUND",
-                EstimatedTransitDays = 3,
-                Cost = 60,
-                xp = new ShipMethodXP { }
-            };
-            var worksheet = BuildOrderWorksheet(line1);
-            var estimates = BuildEstimates(new[] { method1 }, new[] { shipItem1 });
-            var result = ApplyFlatRateShipping(worksheet, estimates, "027", null);
-            var methods = result[0].ShipMethods;
-
-            Assert.AreEqual(1, methods.Count());
-            Assert.AreEqual(FLAT_RATE_FIRST_TIER, methods[0].Cost);
-            Assert.AreEqual(method1.Name, methods[0].Name);
-        }
-
-        [Test]
-        public void flatrateshipping_handle_first_tier_multiple_lines()
-        {
-            // set shipping cost to $29.99 if line item cost is between 0.01$ and $499.99
-            var shipItem1 = new ShipEstimateItem
-            {
-                LineItemID = "Line1"
-            };
-            var shipItem2 = new ShipEstimateItem
-            {
-                LineItemID = "Line2"
-            };
-            var line1 = new HSLineItem
-            {
-                ID = "Line1",
-                LineSubtotal = 200,
-                SupplierID = "027"
-            };
-            var line2 = new HSLineItem
-            {
-                ID = "Line2",
-                LineSubtotal = 250,
-                SupplierID = "027"
-            };
-            var method1 = new HSShipMethod
-            {
-                Name = "FEDEX_GROUND",
-                EstimatedTransitDays = 3,
-                Cost = 60,
-                xp = new ShipMethodXP { }
-            };
-            var worksheet = BuildOrderWorksheet(line1, line2);
-            var estimates = BuildEstimates(new[] { method1 }, new[] { shipItem1, shipItem2 });
-            var result = ApplyFlatRateShipping(worksheet, estimates, "027", null);
-            var methods = result[0].ShipMethods;
-
-            Assert.AreEqual(1, methods.Count());
-            Assert.AreEqual(FLAT_RATE_FIRST_TIER, methods[0].Cost);
-            Assert.AreEqual(method1.Name, methods[0].Name);
-        }
-
-        [Test]
-        public void flatrateshipping_handle_second_tier()
-        {
-            // set shipping cost to $0 if line item cost is greater than $499.99
-            var shipItem1 = new ShipEstimateItem
-            {
-                LineItemID = "Line1"
-            };
-            var line1 = new HSLineItem
-            {
-                ID = "Line1",
-                LineSubtotal = 602,
-                SupplierID = "027"
-            };
-            var method1 = new HSShipMethod
-            {
-                Name = "FEDEX_GROUND",
-                EstimatedTransitDays = 3,
-                Cost = 60,
-                xp = new ShipMethodXP { }
-            };
-            var worksheet = BuildOrderWorksheet(line1);
-            var estimates = BuildEstimates(new[] { method1 }, new[] { shipItem1 });
-            var result = ApplyFlatRateShipping(worksheet, estimates, "027", null);
-            var methods = result[0].ShipMethods;
-
-            Assert.AreEqual(1, methods.Count());
-            Assert.AreEqual(FLAT_RATE_SECOND_TIER, methods[0].Cost);
-            Assert.AreEqual(method1.Name, methods[0].Name);
-        }
-
-        private IList<HSShipEstimate> ApplyFlatRateShipping(HSOrderWorksheet worksheet, List<HSShipEstimate> estimates, string medlineSupplierID, string laliciousSupplierID)
-        {
-            return CheckoutIntegrationCommand.ApplyFlatRateShipping(worksheet, estimates);
-        }
-
-        [Test]
-        public void flatrateshipping_handle_second_tier_multiple_lines()
-        {
-            // set shipping cost to $0 if line item cost is greater than $499.99
-            var shipItem1 = new ShipEstimateItem
-            {
-                LineItemID = "Line1"
-            };
-            var shipItem2 = new ShipEstimateItem
-            {
-                LineItemID = "Line2"
-            };
-            var line1 = new HSLineItem
-            {
-                ID = "Line1",
-                LineSubtotal = 250,
-                SupplierID = "027"
-            };
-            var line2 = new HSLineItem
-            {
-                ID = "Line2",
-                LineSubtotal = 250,
-                SupplierID = "027"
-            };
-            var method1 = new HSShipMethod
-            {
-                Name = "FEDEX_GROUND",
-                EstimatedTransitDays = 3,
-                Cost = 60,
-                xp = new ShipMethodXP { }
-            };
-            var worksheet = BuildOrderWorksheet(line1, line2);
-            var estimates = BuildEstimates(new[] { method1 }, new[] { shipItem1, shipItem2 });
-            var result = ApplyFlatRateShipping(worksheet, estimates, "027", null);
-            var methods = result[0].ShipMethods;
-
-            Assert.AreEqual(1, methods.Count());
-            Assert.AreEqual(FLAT_RATE_SECOND_TIER, methods[0].Cost);
-            Assert.AreEqual(method1.Name, methods[0].Name);
-        }
-
-        [Test]
-        public void flatrateshipping_multiple_methods_with_qualifyingflatrate()
-        {
-            // If qualifies for flat rate shipping then the only rate that should be returned is the modified ground option
-            // this test ensures the non-ground option is stripped out
-            var shipItem1 = new ShipEstimateItem
-            {
-                LineItemID = "Line1"
-            };
-            var shipItem2 = new ShipEstimateItem
-            {
-                LineItemID = "Line2"
-            };
-            var line1 = new HSLineItem
-            {
-                ID = "Line1",
-                LineSubtotal = 250,
-                SupplierID = "027"
-            };
-            var line2 = new HSLineItem
-            {
-                ID = "Line2",
-                LineSubtotal = 130,
-                SupplierID = "027"
-            };
-            var method1 = new HSShipMethod
-            {
-                Name = "FEDEX_GROUND",
-                EstimatedTransitDays = 3,
-                Cost = 60,
-                xp = new ShipMethodXP { }
-            };
-            var method2 = new HSShipMethod
-            {
-                Name = "PRIORITY_OVERNIGHT",
-                EstimatedTransitDays = 1,
-                Cost = 120,
-                xp = new ShipMethodXP { }
-            };
-            var worksheet = BuildOrderWorksheet(line1, line2);
-            var estimates = BuildEstimates(new[] { method1, method2 }, new[] { shipItem1, shipItem2 });
-            var result = ApplyFlatRateShipping(worksheet, estimates, "027", null);
-            var methods = result[0].ShipMethods;
-
-            Assert.AreEqual(1, methods.Count());
-            Assert.AreEqual(FLAT_RATE_FIRST_TIER, methods[0].Cost);
-            Assert.AreEqual(method1.Name, methods[0].Name);
-        }
-
-        [Test]
-        public void flatrateshipping_multiple_methods_with_nonqualifyingflatrate()
-        {
-            // If DOESNT qualify for flat rate shipping then dont modify the rates
-            var shipItem1 = new ShipEstimateItem
-            {
-                LineItemID = "Line1"
-            };
-            var shipItem2 = new ShipEstimateItem
-            {
-                LineItemID = "Line2"
-            };
-            var line1 = new HSLineItem
-            {
-                ID = "Line1",
-                LineSubtotal = 250,
-                SupplierID = "027"
-            };
-            var line2 = new HSLineItem
-            {
-                ID = "Line2",
-                LineSubtotal = 130,
-                SupplierID = "027"
-            };
-            var method1 = new HSShipMethod
-            {
-                Name = "SOMETHING_ELSE",
-                EstimatedTransitDays = 3,
-                Cost = 60,
-                xp = new ShipMethodXP { }
-            };
-            var method2 = new HSShipMethod
-            {
-                Name = "PRIORITY_OVERNIGHT",
-                EstimatedTransitDays = 1,
-                Cost = 120,
-                xp = new ShipMethodXP { }
-            };
-            var worksheet = BuildOrderWorksheet(line1, line2);
-            var estimates = BuildEstimates(new[] { method1, method2 }, new[] { shipItem1, shipItem2 });
-            var result = ApplyFlatRateShipping(worksheet, estimates, "027", null);
-            var methods = result[0].ShipMethods;
-
-            Assert.AreEqual(2, methods.Count());
-            Assert.AreEqual(method1.Cost, methods[0].Cost);
-            Assert.AreEqual(method1.Name, methods[0].Name);
-            Assert.AreEqual(method2.Cost, methods[1].Cost);
-            Assert.AreEqual(method2.Name, methods[1].Name);
-        }
-
-        [Test]
-        public void flatrateshipping_handle_multiple_estimates()
-        {
-            // set shipping cost to $0 if line item cost is greater than $499.99
-            var shipItem1 = new ShipEstimateItem
-            {
-                LineItemID = "Supplier1Line1"
-            };
-            var shipitem2 = new ShipEstimateItem
-            {
-                LineItemID = "Supplier2Line1"
-            };
-            var line1 = new HSLineItem
-            {
-                ID = "Supplier1Line1",
-                LineSubtotal = 110,
-                SupplierID = "010"
-            };
-            var line2 = new HSLineItem
-            {
-                ID = "Supplier1Line2",
-                LineSubtotal = 125,
-                SupplierID = "010"
-            };
-            var line3 = new HSLineItem
-            {
-                ID = "Supplier2Line1",
-                LineSubtotal = 130,
-                SupplierID = "027"
-            };
-            var line4 = new HSLineItem
-            {
-                ID = "Supplier2Line2",
-                LineSubtotal = 180,
-                SupplierID = "027"
-            };
-            var method1 = new HSShipMethod
-            {
-                Name = "FEDEX_GROUND",
-                EstimatedTransitDays = 1,
-                Cost = 80,
-                xp = new ShipMethodXP { }
-            };
-            var method2 = new HSShipMethod
-            {
-                Name = "FEDEX_GROUND",
-                EstimatedTransitDays = 3,
-                Cost = 60,
-                xp = new ShipMethodXP { }
-            };
-            var worksheet = BuildOrderWorksheet(line1, line2, line3, line4);
-            var estimates = BuildEstimates(new[] { method1 }, new[] { shipItem1 });
-            estimates.AddRange(BuildEstimates(new[] { method2 }, new[] { shipitem2 }));
-            var result = ApplyFlatRateShipping(worksheet, estimates, "027", null);
-
-            Assert.AreEqual(2, result.Count());
-            // compare first shipment item from first estimate (no changes because its not medline supplier)
-            Assert.AreEqual(1, result[0].ShipMethods.Count());
-            Assert.AreEqual(method1.Name, result[0].ShipMethods[0].Name);
-            Assert.AreEqual(method1.Cost, result[0].ShipMethods[0].Cost);
-
-            // compare first shipment item from second estimate (cost falls in first tier between $0.01 and $499.9)
-            Assert.AreEqual(1, result[0].ShipMethods.Count());
-            Assert.AreEqual(method2.Name, result[1].ShipMethods[0].Name);
-            Assert.AreEqual(29.99M, result[1].ShipMethods[0].Cost);
-        }
         #endregion
 
-        private List<HSShipEstimate> BuildEstimates( HSShipMethod[] shipMethods, ShipEstimateItem[] shipItems = null)
+        #region SetupMethods
+        private List<HSShipEstimate> BuildEstimates(HSShipMethod[] shipMethods, ShipEstimateItem[] shipItems = null, string id = "mockID")
         {
             return new List<HSShipEstimate>
             {
                 new HSShipEstimate
                 {
+                    ID = id,
                     ShipMethods = shipMethods.ToList(),
                     ShipEstimateItems = shipItems?.ToList()
                 }
             };
         }
 
-        private HSOrderWorksheet BuildOrderWorksheet(params HSLineItem[] lineItems)
+        private HSOrderWorksheet BuildOrderWorksheet(HSLineItem[] lineItems, string buyerUserCountry = "US")
         {
             return new HSOrderWorksheet
             {
+                Order = new HSOrder()
+                {
+                    FromUser = new HSUser()
+                    {
+                        xp = new UserXp
+                        {
+                            Country = buyerUserCountry
+                        }
+                    }
+                },
                 LineItems = lineItems.ToList()
             };
         }
+        private HSSupplier MockSupplier(string id = "mockID", int freeShippingThreshold = 500)
+        {
+            return new HSSupplier
+            {
+                ID = id,
+                xp = new SupplierXp
+                {
+                    FreeShippingThreshold = freeShippingThreshold,
+                }
+            };
+        }
+        #endregion
     }
 }

--- a/src/Middleware/tests/Headstart.Tests/Mocks/SupplierMocks.cs
+++ b/src/Middleware/tests/Headstart.Tests/Mocks/SupplierMocks.cs
@@ -1,0 +1,34 @@
+﻿using Headstart.Models.Headstart;
+using ordercloud.integrations.cardconnect;
+using OrderCloud.SDK;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Headstart.Tests.Mocks
+{
+    public static class SupplierMocks
+    {
+        public static List<HSSupplier> Suppliers(params HSSupplier[] suppliers)
+        {
+            return new List<HSSupplier>(suppliers);
+        }
+
+        public static ListPage<HSSupplier> EmptySuppliersList()
+        {
+            var items = new List<HSSupplier>();
+            return new ListPage<HSSupplier>
+            {
+                Items = items
+            };
+        }
+
+        public static ListPage<HSSupplier> SupplierList(params HSSupplier[] suppliers)
+        {
+            return new ListPage<HSSupplier>
+            {
+                Items = new List<HSSupplier>(suppliers)
+            };
+        }
+    }
+}

--- a/src/UI/Buyer/src/app/app.module.ts
+++ b/src/UI/Buyer/src/app/app.module.ts
@@ -204,6 +204,7 @@ import { CMSConfiguration } from '@ordercloud/cms-sdk'
 import { AppConfig } from './models/environment.types'
 import { OCMKitLineitemTable } from './components/cart/lineitem-table/kit-lineitem-table/kit-lineitem-table.component'
 import { BaseResolveService } from './services/base-resolve/base-resolve.service'
+import { ShipMethodNameMapperPipe } from './pipes/ship-method-name/ship-method-name.pipe'
 
 export function HttpLoaderFactory(
   http: HttpClient,
@@ -332,6 +333,7 @@ const components = [
     CreditCardInputDirective,
     SpecFieldDirective,
     ProductNameWithSpecsPipe,
+    ShipMethodNameMapperPipe,
     KitProductNameWithSpecsPipe,
     OrderStatusDisplayPipe,
     PhoneFormatPipe,

--- a/src/UI/Buyer/src/app/components/checkout/shipping-selection-form/shipping-selection-form.component.html
+++ b/src/UI/Buyer/src/app/components/checkout/shipping-selection-form/shipping-selection-form.component.html
@@ -18,14 +18,15 @@
       *ngFor="let shipMethod of _shipEstimate?.ShipMethods"
       [ngValue]="shipMethod.ID"
     >
-      {{ shipMethod.EstimatedTransitDays }}
-      <span translate>CHECKOUT.SHIPPING_SELECTION_FORM.DAY</span
-      >{{ detectPlural(shipMethod.EstimatedTransitDays) }} -
       {{
         shipMethod.xp.FreeShippingApplied
           ? 'FREE'
           : (shipMethod.Cost | currency: _orderCurrency)
       }}
+      - {{ shipMethod?.Name | shipMethodNameMapper }} est.
+      {{ getEstTransitDays(shipMethod) }}
+      <span translate>CHECKOUT.SHIPPING_SELECTION_FORM.DAY</span
+      >{{ detectPlural(shipMethod) }}
     </option>
   </select>
 </form>

--- a/src/UI/Buyer/src/app/components/checkout/shipping-selection-form/shipping-selection-form.component.ts
+++ b/src/UI/Buyer/src/app/components/checkout/shipping-selection-form/shipping-selection-form.component.ts
@@ -1,5 +1,9 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core'
-import { ShipEstimate, ShipMethodSelection } from 'ordercloud-javascript-sdk'
+import {
+  ShipEstimate,
+  ShipMethod,
+  ShipMethodSelection,
+} from 'ordercloud-javascript-sdk'
 import { FormGroup, FormControl } from '@angular/forms'
 import {
   faExclamationTriangle,
@@ -48,5 +52,16 @@ export class OCMShippingSelectionForm implements OnInit {
 
   detectPlural(value: number): string {
     return value === 1 ? '' : 's'
+  }
+
+  getEstTransitDays(method: ShipMethod): number {
+    // If current day is Friday, Standard Overnight will return 3 days
+    // as the estimated delivery days since there is only delivery on
+    // business days.  We want to override this so it is always 1 day.
+    // Documentation: https://www.easypost.com/fedex-guide#levels
+    if (method.Name === 'STANDARD_OVERNIGHT') {
+      return 1
+    }
+    return method.EstimatedTransitDays
   }
 }

--- a/src/UI/Buyer/src/app/pipes/ship-method-name/ship-method-name.pipe.spec.ts
+++ b/src/UI/Buyer/src/app/pipes/ship-method-name/ship-method-name.pipe.spec.ts
@@ -1,0 +1,18 @@
+import { ShipMethodNameMapperPipe } from "./ship-method-name.pipe";
+
+describe('ShipMethodNameMapperPipe', () => {
+    // This pipe is a pure, stateless function so no need for BeforeEach
+    const pipe = new ShipMethodNameMapperPipe();
+  
+    it('transforms "FEDEX_GROUND" to "Ground"', () => {
+      expect(pipe.transform('FEDEX_GROUND')).toBe('Ground');
+    });
+  
+    it('transforms "null" to ""', () => {
+      expect(pipe.transform(null)).toBe('');
+    });
+
+    it('transforms "NON_EXISTENT_METHOD" to "NON_EXISTENT_METHOD"', () => {
+      expect(pipe.transform('NON_EXISTENT_METHOD')).toBe('NON_EXISTENT_METHOD');
+    });
+  });

--- a/src/UI/Buyer/src/app/pipes/ship-method-name/ship-method-name.pipe.ts
+++ b/src/UI/Buyer/src/app/pipes/ship-method-name/ship-method-name.pipe.ts
@@ -1,0 +1,36 @@
+import { Pipe, PipeTransform } from '@angular/core'
+
+@Pipe({
+  name: 'shipMethodNameMapper',
+})
+export class ShipMethodNameMapperPipe implements PipeTransform {
+  transform(methodName: string): string {
+    if (!methodName) return ''
+
+    const methodNameMapper: { [key: string]: string } = {
+      ['Priority']: 'Prority',
+      ['First']: 'Priority First',
+      ['ParcelSelect']: 'Economical Ground',
+      ['Express']: 'Priority Express',
+      ['FIRST_OVERNIGHT']: 'First Overnight',
+      ['PRIORITY_OVERNIGHT']: 'Priority Overnight',
+      ['STANDARD_OVERNIGHT']: 'Standard Overnight',
+      ['FEDEX_2_DAY']: '2 Day',
+      ['FEDEX_GROUND']: 'Ground',
+      ['FREE_SHIPPING']: '',
+    }
+    let mappedMethodName: string = methodName.includes('No shipping rates')
+      ? methodNameMapper['FREE_SHIPPING']
+      : methodNameMapper[methodName]
+
+    if (!methodName.includes('No shipping rates')) {
+      mappedMethodName = `${mappedMethodName} -`
+    }
+
+    if (mappedMethodName !== null || mappedMethodName !== undefined) {
+      return mappedMethodName
+    } else {
+      return methodName
+    }
+  }
+}


### PR DESCRIPTION
## Description
- Shipping logic brought to HeadStart
- Using SMG's FedEx account, we are returning Ground, Next Day and 2 Day shipping rates.
- There is some commented out code in there for ShippingCostSchedule logic.  Decision makers are still deciding if that should be brought to HeadStart, or simply removed.
- When checking out, you should now receive back 3 shipping rates.
- The way shipping rates are displayed in the Shipping Selection Form is also migrated to match the way SEB's look, with more descriptive, intuitive text.
- Migrated over some shipping tests from SEB as well.

For Reference: [HDS-209](https://four51.atlassian.net/browse/HDS-209) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
