### PR TITLE
HDS-221 and HDS-47 (updates to checkout and anon shopping)

### DIFF
--- a/src/Middleware/src/Headstart.API/Controllers/ValidatedAddressController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/ValidatedAddressController.cs
@@ -1,4 +1,4 @@
-﻿using Headstart.Models.Attributes;
+using Headstart.Models.Attributes;
 using Microsoft.AspNetCore.Mvc;
 using OrderCloud.SDK;
 using System.Threading.Tasks;
@@ -22,7 +22,13 @@ namespace Headstart.Common.Controllers
 		[HttpPost, Route("me/addresses"), OrderCloudUserAuth(ApiRole.MeAddressAdmin)]
 		public async Task<BuyerAddress> CreateMeAddress([FromBody] BuyerAddress address) =>
 			await _command.CreateMeAddress(address, UserContext);
-	
+
+		[HttpPost, Route("me/addresses/validate")]
+		public async Task<BuyerAddress> ValidateAddress([FromBody] BuyerAddress address)
+        {
+			var validation = await _command.ValidateAddress(address);
+			return validation.ValidAddress;
+        }
 
 		[HttpPut, Route("me/addresses/{addressID}"), OrderCloudUserAuth(ApiRole.MeAddressAdmin)]
 		public async Task<BuyerAddress> SaveMeAddress(string addressID, [FromBody] BuyerAddress address) =>

--- a/src/UI/Buyer/src/app/components/checkout/checkout-address/checkout-address.component.html
+++ b/src/UI/Buyer/src/app/components/checkout/checkout-address/checkout-address.component.html
@@ -8,32 +8,6 @@
   >
     <small>Loading Shipping Selections...</small>
   </ngx-spinner>
-  <div class="form-group" *ngIf="!isAnon">
-    <label for="selectBuyerLocation" translate
-      >CHECKOUT.CHECKOUT_ADDRESS.BUYER_LOCATION</label
-    >
-    <select
-      [ngModel]="selectedBuyerLocation?.ID"
-      (ngModelChange)="onBuyerLocationChange($event)"
-      class="custom-select"
-      id="selectBuyerLocation"
-    >
-      <option [ngValue]="null" default disabled translate>
-        CHECKOUT.CHECKOUT_ADDRESS.SELECT_BUYER_LOCATION
-      </option>
-      <option
-        *ngFor="let location of existingBuyerLocations?.Items"
-        [ngValue]="location.ID"
-      >
-        <span class="font-weight-bold"
-          >{{ location.Street1
-          }}<span *ngIf="location.Street2"> {{ location.Street2 }}</span
-          >, {{ location.City }} {{ location.State }} {{ location.Zip }}</span
-        >
-      </option>
-    </select>
-    <br />
-  </div>
   <div class="form-group" *ngIf="selectedBuyerLocation">
     <label for="selectAddress" translate
       >CHECKOUT.CHECKOUT_ADDRESS.SHIPPING_ADDRESS</label

--- a/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.html
+++ b/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.html
@@ -93,6 +93,7 @@
   <ocm-payment-credit-card
     *ngIf="orderSummaryMeta.StandardLineItemCount"
     [cards]="cards"
+    [isAnon]="isAnon"
     [termsAccepted]="POTermsAccepted"
     [paymentError]="paymentError"
     (cardSelected)="onCardSelected($event.detail)"

--- a/src/UI/Buyer/src/app/components/payments/credit-card-form/credit-card-form.component.html
+++ b/src/UI/Buyer/src/app/components/payments/credit-card-form/credit-card-form.component.html
@@ -96,6 +96,21 @@
     </div>
   </div>
   <div *ngIf="_showCardDetails">
+    <div class="form-check d-flex justify-content-between mb-2">
+    <input
+      type="checkbox"
+      (click)="mapShippingAddressToBilling($event)"
+      formControlName="useShippingAddress"
+      class="form-check-input"
+      id="useShippingAddress"
+    />
+    <label
+      class="form-check-label text-muted"
+      for="useShippingAddress" 
+      translate
+      >Use shipping address as billing</label
+    >
+    </div>
     <div class="row align-items-center">
       <label class="small text-muted col-12" for="accepted-cards" translate
         >PAYMENTS.CC_FORM.BILLING_ADDRESS</label

--- a/src/UI/Buyer/src/app/components/payments/payment-credit-card/payment-credit-card.component.html
+++ b/src/UI/Buyer/src/app/components/payments/payment-credit-card/payment-credit-card.component.html
@@ -15,13 +15,14 @@
         [card]="card"
       ></ocm-credit-card-display>
     </option>
-    <option [value]="new" translate>PAYMENTS.PAYMENT.ADD_CC</option>
+    <option value="new" translate>PAYMENTS.PAYMENT.ADD_CC</option>
   </select>
   <ocm-credit-card-form
     [submitText]="'Save and Continue'"
     [showCVV]="true"
     [showCardDetails]="_showNewCCForm"
     [termsAccepted]="termsAccepted"
+    [isAnon]="isAnon"
     (formSubmitted)="submit($event.detail)"
     class="w-100"
   >

--- a/src/UI/Buyer/src/app/components/payments/payment-credit-card/payment-credit-card.component.ts
+++ b/src/UI/Buyer/src/app/components/payments/payment-credit-card/payment-credit-card.component.ts
@@ -18,6 +18,7 @@ export class OCMPaymentCreditCard implements OnInit {
       this._showNewCCForm = false
     }
   } 
+  @Input() isAnon: boolean
   @Input() termsAccepted: boolean
   @Input() paymentError: string
   @Output() cardSelected = new EventEmitter<SelectedCreditCard>()

--- a/src/UI/Buyer/src/app/services/addresses/address.service.ts
+++ b/src/UI/Buyer/src/app/services/addresses/address.service.ts
@@ -81,6 +81,13 @@ export class AddressService {
     return response.data;
   }
 
+  // eventually replace with sdk
+  async validateAddress(address: HSAddressBuyer): Promise<HSAddressBuyer>  {
+    var url = `${this.appConfig.middlewareUrl}/me/addresses/validate`
+    var response = await Axios.post(url, address, this.BuildConfig());
+    return response.data;
+  }
+
   BuildConfig(): AxiosRequestConfig {
     return { headers: { Authorization: `Bearer ${Tokens.GetAccessToken()}`}};
   }

--- a/src/UI/Buyer/src/app/services/order/order.service.ts
+++ b/src/UI/Buyer/src/app/services/order/order.service.ts
@@ -9,6 +9,7 @@ import {
   Order,
   LineItem,
   IntegrationEvents,
+  ListPage,
 } from 'ordercloud-javascript-sdk'
 import {
   HSOrder,
@@ -40,6 +41,10 @@ export class CurrentOrderService {
 
   get(): HSOrder {
     return this.state.order
+  }
+
+  getLineItems(): ListPage<HSLineItem> {
+    return this.state.lineItems
   }
 
   get cart(): CartService {


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
1. Remove step where users select franchise location 
2. Use billing address on credit card for billing address on order
3. add route for vaildating an address without creating / saving (for anonymous users).
4. Add option to automatically fill in billing address in CC form with shipping address

For Reference: [HDS-221](https://four51.atlassian.net/browse/HDS-221) <!--  Ignore if PR from external developer -->

- [x ] I have updated the acceptance criteria on the task so that it can be tested
