### PR TITLE
HDS-224 - remove inherited OCSettings class.

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
@@ -54,7 +54,7 @@ namespace Headstart.API.Commands
 
         public async Task<EnvironmentSeedResponse> Seed(EnvironmentSeed seed)
         {
-            var requestedEnv = validateEnvironment(seed.OrderCloudSettings.Environment);
+            OcEnv requestedEnv = validateEnvironment(seed.OrderCloudSettings.Environment);
 
             if (string.IsNullOrEmpty(seed.OrderCloudSettings.WebhookHashKey))
             {

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -90,11 +90,14 @@ namespace Headstart.Models.Misc
 		public Dictionary<string, dynamic> ApiClients { get; set; }
     }
 
-	public class OrderCloudSeedRequest : OrderCloudSettings
+	public class OrderCloudSeedRequest
 	{
 		[Required]
 		[ValueRange(AllowableValues = new[] { "production", "prod", "sandbox" })]
 		public string Environment { get; set; }
+		public string WebhookHashKey { get; set; }
+		public string MiddlewareClientID { get; set; }
+		public string MiddlewareClientSecret { get; set; }
 	}
 
 	public class OrderCloudEnvironments


### PR DESCRIPTION

## Description - Remove inherited class to avoid confusion. Note: the clientID and clientSecret aren't inherently required, but we do take it off the OrderCloudSettings from this call, or the OCSettings that are in the azure configs if the ones passed in are null.

For Reference: [HDS-224](https://four51.atlassian.net/browse/HDS-224)
