### PR TITLE
Fixed BuildNumber reference in Docker build pipeline

### DIFF
--- a/docker-azure-pipelines.yml
+++ b/docker-azure-pipelines.yml
@@ -2,9 +2,6 @@ resources:
   - repo: self
     clean: true
 
-variables:
-- name: build.updatebuildnumber
-  value: ""
 stages:
   - stage: Build_Headstart
     displayName: "Build Headstart Images"
@@ -21,7 +18,7 @@ stages:
             inputs:
               targetType: "inline"
               script: |
-                $version = if ([string]::IsNullOrEmpty("$(build.updatebuildnumber)")) {"latest"} else {"$(build.updatebuildnumber)"}
+                $version = if ([string]::IsNullOrEmpty("$(Build.BuildNumber)")) {"latest"} else {"$(Build.BuildNumber)"}
 
                 az login -u "$(container.registry.username)" -p "$(container.registry.password)" -t "$(container.registry.tenant)"
                 az acr login -n $(container.registry.short)


### PR DESCRIPTION
Fixed BuildNumber reference in Docker build pipeline, it was initially set incorrectly and always resulted into "latest" being used.
