### PR TITLE
HDS-217 specify blob as an allowed image source

### DIFF
--- a/src/UI/Seller/src/web.config
+++ b/src/UI/Seller/src/web.config
@@ -20,7 +20,7 @@
         <add name="Cache-Control" value="no-cache, no-store"/>
         <add name="X-Content-Type-Options" value="nosniff" />
         <add name="Referrer-Policy" value="no-referrer-when-downgrade"/>
-        <add name="Content-Security-Policy" value="default-src 'self'; connect-src *; font-src *; frame-src *; img-src * 'self'; data: https; media-src *; object-src *; script-src * 'unsafe-inline' 'unsafe-eval'; style-src * 'unsafe-inline';" />
+        <add name="Content-Security-Policy" value="default-src 'self'; connect-src *; font-src *; frame-src *; img-src * 'self'; data: https blob; media-src *; object-src *; script-src * 'unsafe-inline' 'unsafe-eval'; style-src * 'unsafe-inline';" />
         <add name="Feature-Policy" value="accelerometer 'none'; ambient-light-sensor 'none'; animations *; autoplay *; camera 'none'; display-capture *; document-write *; encrypted-media *; fullscreen *; geolocation 'none'; gyroscope 'none'; image-compression *; layout-animations *; legacy-image-formats *; magnetometer 'none'; max-downscaling-image *; microphone 'none'; midi 'none'; oversized-images *; payment 'none'; picture-in-picture *; publickey-credentials 'none'; speaker *; sync-xhr *; unsized-media *; usb 'none'; vr 'none'; vertical-scroll *; wake-lock 'none';" />
       </customHeaders>
     </httpProtocol>

--- a/src/UI/Seller/src/web.config
+++ b/src/UI/Seller/src/web.config
@@ -20,7 +20,7 @@
         <add name="Cache-Control" value="no-cache, no-store"/>
         <add name="X-Content-Type-Options" value="nosniff" />
         <add name="Referrer-Policy" value="no-referrer-when-downgrade"/>
-        <add name="Content-Security-Policy" value="default-src 'self'; connect-src *; font-src *; frame-src *; img-src * 'self'; data: https blob; media-src *; object-src *; script-src * 'unsafe-inline' 'unsafe-eval'; style-src * 'unsafe-inline';" />
+        <add name="Content-Security-Policy" value="default-src 'self'; connect-src *; font-src *; frame-src *; img-src * blob: 'self'; data: https; media-src *; object-src *; script-src * 'unsafe-inline' 'unsafe-eval'; style-src * 'unsafe-inline';" />
         <add name="Feature-Policy" value="accelerometer 'none'; ambient-light-sensor 'none'; animations *; autoplay *; camera 'none'; display-capture *; document-write *; encrypted-media *; fullscreen *; geolocation 'none'; gyroscope 'none'; image-compression *; layout-animations *; legacy-image-formats *; magnetometer 'none'; max-downscaling-image *; microphone 'none'; midi 'none'; oversized-images *; payment 'none'; picture-in-picture *; publickey-credentials 'none'; speaker *; sync-xhr *; unsized-media *; usb 'none'; vr 'none'; vertical-scroll *; wake-lock 'none';" />
       </customHeaders>
     </httpProtocol>


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Need to specify blob as an allowed data source in our web config images that are uploaded have this url before they are saved: blob:https://headstartdemo-admin-ui-test.azurewebsites.net/...

For Reference: [HDS-217](https://four51.atlassian.net/browse/HDS-217) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
