### PR TITLE
HDS-276 add global retries

### DIFF
--- a/src/Middleware/integrations/ordercloud.integrations.easypost/ordercloud.integrations.easypost.csproj
+++ b/src/Middleware/integrations/ordercloud.integrations.easypost/ordercloud.integrations.easypost.csproj
@@ -1,13 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Polly" Version="7.2.1" />
-    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ordercloud.integrations.library\ordercloud.integrations.library.csproj" />

--- a/src/Middleware/src/Headstart.API/Commands/OrderSubmitCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/OrderSubmitCommand.cs
@@ -2,17 +2,12 @@ using Headstart.Models;
 using ordercloud.integrations.cardconnect;
 using ordercloud.integrations.library;
 using OrderCloud.SDK;
-using Polly;
-using Polly.Retry;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
 using System.Net;
-using Newtonsoft.Json;
 using Headstart.Common.Services.ShippingIntegration.Models;
 using Headstart.Models.Headstart;
 using Headstart.Common;
@@ -50,7 +45,7 @@ namespace Headstart.API.Commands
             }
             try
             {
-                return await WithRetry().ExecuteAsync(() => _oc.Orders.SubmitAsync<HSOrder>(direction, incrementedOrderID, userToken));
+                return await _oc.Orders.SubmitAsync<HSOrder>(direction, incrementedOrderID, userToken);
             }
             catch (Exception)
             {
@@ -149,18 +144,6 @@ namespace Headstart.API.Commands
                 merchantID = _settings.CardConnectSettings.EurMerchantID;
 
             return merchantID;
-        }
-
-        private AsyncRetryPolicy WithRetry()
-        {
-            // retries three times, waits two seconds in-between failures
-            return Policy
-                .Handle<OrderCloudException>(e => e.HttpStatus == HttpStatusCode.InternalServerError || e.HttpStatus == HttpStatusCode.RequestTimeout)
-                .WaitAndRetryAsync(new[] {
-                    TimeSpan.FromSeconds(2),
-                    TimeSpan.FromSeconds(2),
-                    TimeSpan.FromSeconds(2),
-                });
         }
     }
 }

--- a/src/Middleware/src/Headstart.API/Startup.cs
+++ b/src/Middleware/src/Headstart.API/Startup.cs
@@ -12,7 +12,6 @@ using Headstart.Common.Repositories;
 using Headstart.Common.Services;
 using Headstart.Common.Services.CMS;
 using Headstart.Common.Services.Zoho;
-using LazyCache;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -31,8 +30,10 @@ using System.Collections.Generic;
 using System.Net;
 using Microsoft.OpenApi.Models;
 using OrderCloud.Catalyst;
-using OrderCloud.Common.Services;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Polly;
+using Polly.Extensions.Http;
+using Polly.Contrib.WaitAndRetry;
 
 namespace Headstart.API
 {
@@ -180,6 +181,16 @@ namespace Headstart.API
 
             ServicePointManager.DefaultConnectionLimit = int.MaxValue;
             FlurlHttp.Configure(settings => settings.Timeout = TimeSpan.FromSeconds(_settings.FlurlSettings.TimeoutInSeconds));
+
+            // This adds retry logic for any api call that fails with a transient error (server errors, timeouts, or rate limiting requests)
+            // Will retry up to 3 times using exponential backoff and jitter, a mean of 3 seconds wait time in between retries
+            // https://github.com/App-vNext/Polly/wiki/Retry-with-jitter#more-complex-jitter
+            var delay = Backoff.DecorrelatedJitterBackoffV2(medianFirstRetryDelay: TimeSpan.FromSeconds(3), retryCount: 3);
+            var policy = HttpPolicyExtensions
+                            .HandleTransientHttpError()
+                            .OrResult(response => response.StatusCode == HttpStatusCode.TooManyRequests)
+                            .WaitAndRetryAsync(delay);
+            FlurlHttp.Configure(settings => settings.HttpClientFactory = new PollyFactory(policy));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Middleware/src/Headstart.Common/Headstart.Common.csproj
+++ b/src/Middleware/src/Headstart.Common/Headstart.Common.csproj
@@ -29,6 +29,9 @@
     <PackageReference Include="NPOI" Version="2.4.1" />
     <PackageReference Include="Npoi.Mapper" Version="3.4.0" />
     <PackageReference Include="OrderCloud.SDK" Version="0.10.1" />
+    <PackageReference Include="Polly" Version="7.2.1" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="SendGrid" Version="9.22.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.0.1" />
   </ItemGroup>

--- a/src/Middleware/src/Headstart.Common/PollyFactory.cs
+++ b/src/Middleware/src/Headstart.Common/PollyFactory.cs
@@ -1,0 +1,46 @@
+﻿using Flurl.Http.Configuration;
+using Polly;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Headstart.Common
+{
+    // Polly is our resilience library and Flurl is our http library
+    // This PollyFactory lets us express a default resilience policy
+    // for our app on any flurl http call
+    // https://stackoverflow.com/a/52284010/6147893
+
+    public class PollyFactory : DefaultHttpClientFactory
+    {
+        private readonly IAsyncPolicy<HttpResponseMessage> _policy;
+
+        public PollyFactory(IAsyncPolicy<HttpResponseMessage> policy)
+        {
+            _policy = policy;
+        }
+
+        public override HttpMessageHandler CreateMessageHandler()
+        {
+            return new PollyHandler(_policy)
+            {
+                InnerHandler = base.CreateMessageHandler()
+            };
+        }
+    }
+
+    public class PollyHandler : DelegatingHandler
+    {
+        private readonly IAsyncPolicy<HttpResponseMessage> _policy;
+
+        public PollyHandler(IAsyncPolicy<HttpResponseMessage> policy)
+        {
+            _policy = policy;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return _policy.ExecuteAsync(ct => base.SendAsync(request, ct), cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Similar to SEB add retries in a single global location. This will clean up retries that are currently littering the codebase throughout and consolidate into one spot.

For Reference: [HDS-276 ](https://four51.atlassian.net/browse/HDS-276 ) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
