### PR TITLE
HDS-279: Make "Create" button visible in New Promotion form

### DIFF
--- a/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.html
+++ b/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.html
@@ -629,7 +629,7 @@
       </form>
     </div>
     <div class="col-md-5 mt-3 mt-md-0">
-      <div class="sticky-top">
+      <div class="sticky-top pb-1">
         <div class="card bg-white shadow-sm p-4">
           <h6 class="mb-0" translate>ADMIN.PROMOTIONS.SUMMARY</h6>
           <div
@@ -725,8 +725,7 @@
         </div>
         <div class="d-flex flex-row justify-content-end mt-3">
           <button
-            *ngIf="areChanges"
-            class="btn btn-primary mr-2"
+            class="btn btn-primary"
             type="submit"
             [disabled]="resourceForm?.status === 'INVALID' || dataIsSaving"
             (click)="handleSave()"


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description

Make "Create" button visible in New Promotion form. At the moment, it is hidden until something is entered into a field, which is inconsistent with other Create buttons. Also add a little padding to the sticky card.

For Reference: [HDS-279](https://four51.atlassian.net/browse/HDS-279) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
