### PR TITLE
HDS-296: Fix grid spec form bugs

### DIFF
--- a/src/UI/Buyer/src/app/components/cart/lineitem-table/lineitem-table.component.html
+++ b/src/UI/Buyer/src/app/components/cart/lineitem-table/lineitem-table.component.html
@@ -210,7 +210,7 @@
                   [existingQty]="li.Quantity"
                   [product]="li.Product"
                   [li]="li"
-                  [groupedLis]="_lineItems"
+                  [groupedLineItems]="_lineItems"
                   [priceSchedule]="li.Product.PriceSchedule"
                   [isQtyChanging]="isQtyChanging(li.ID)"
                   [variantID]="li.Variant?.ID"

--- a/src/UI/Buyer/src/app/components/cart/lineitem-table/lineitem-table.component.html
+++ b/src/UI/Buyer/src/app/components/cart/lineitem-table/lineitem-table.component.html
@@ -209,6 +209,8 @@
                   *ngIf="!readOnly"
                   [existingQty]="li.Quantity"
                   [product]="li.Product"
+                  [li]="li"
+                  [groupedLis]="_lineItems"
                   [priceSchedule]="li.Product.PriceSchedule"
                   [isQtyChanging]="isQtyChanging(li.ID)"
                   [variantID]="li.Variant?.ID"

--- a/src/UI/Buyer/src/app/components/products/grid-spec-form/grid-spec-form.component.ts
+++ b/src/UI/Buyer/src/app/components/products/grid-spec-form/grid-spec-form.component.ts
@@ -6,7 +6,7 @@ import {
   PriceSchedule,
   SuperHSProduct,
 } from '@ordercloud/headstart-sdk'
-import { PriceBreak, Spec } from 'ordercloud-javascript-sdk'
+import { BuyerProduct, PriceBreak, Spec } from 'ordercloud-javascript-sdk'
 import { ProductDetailService } from '../product-details/product-detail.service'
 import { SpecFormService } from '../spec-form/spec-form.service'
 import { minBy as _minBy } from 'lodash'
@@ -111,22 +111,46 @@ export class OCMGridSpecForm {
       },
     }
     const i = this.lineItems.findIndex(
-      (li) => JSON.stringify(li.Specs) === JSON.stringify(item.Specs)
+      (li: HSLineItem) =>
+        JSON.stringify(li.Specs) === JSON.stringify(item.Specs)
     )
     if (i === -1) this.lineItems.push(item)
     else this.lineItems[i] = item
-    const liQuantities = []
-    this.lineItems.forEach((li) => liQuantities.push(li.Quantity))
+    const liQuantities: number[] = []
+    this.lineItems.forEach((li: HSLineItem) => liQuantities.push(li.Quantity))
     this.totalQtyToAdd = liQuantities.reduce((acc, curr) => {
       return acc + curr
     })
     this.qtyValid = this.validateQuantity(this.lineItems)
-    this.lineTotals[indexOfSpec] = this.getLineTotal(event.qty, item.Specs)
-    this.unitPrices[indexOfSpec] = this.getUnitPrice(event.qty, item.Specs)
+    if (this.priceSchedule?.UseCumulativeQuantity) {
+      // Update all line item totals, to check for price breaks.
+      this.lineItems.forEach((li: HSLineItem, i: number) => {
+        this.lineTotals[i] = this.getLineTotal(
+          li.Quantity,
+          li.Specs as GridSpecOption[],
+          this.totalQtyToAdd,
+          this.priceSchedule?.UseCumulativeQuantity
+        )
+        this.unitPrices[i] = this.getUnitPrice(
+          li.Quantity,
+          li.Specs as GridSpecOption[],
+          this.totalQtyToAdd,
+          this.priceSchedule?.UseCumulativeQuantity
+        )
+      })
+    } else {
+      this.lineTotals[indexOfSpec] = this.getLineTotal(
+        event.qty,
+        item.Specs,
+        this.totalQtyToAdd,
+        this.priceSchedule?.UseCumulativeQuantity
+      )
+      this.unitPrices[indexOfSpec] = this.getUnitPrice(event.qty, item.Specs)
+    }
     this.totalPrice = this.getTotalPrice()
   }
 
-  validateQuantity(lineItems: any[]): boolean {
+  validateQuantity(lineItems: HSLineItem[]): boolean {
     this.resetGridQtyFields = false
     this.errorMsg = ''
     const lineItemsOfCurrentProductInCart: HSLineItem[] = this.context.order.cart
@@ -148,20 +172,24 @@ export class OCMGridSpecForm {
       )
       if (
         this.totalQtyToAdd + qtyInCart <
-        lineItems[0].Product.PriceSchedule.MinQuantity
+        (lineItems[0].Product as BuyerProduct).PriceSchedule.MinQuantity
       ) {
         this.errorMsg = `Minimum quantity not reached.  ${qtyInCart} in cart, ${
-          lineItems[0].Product.PriceSchedule.MinQuantity - qtyInCart
+          (lineItems[0].Product as BuyerProduct).PriceSchedule.MinQuantity -
+          qtyInCart
         } of any product option are needed.`
         return false
       }
       // When users have exceeded the maximum quantity
       if (
-        lineItems[0].Product.PriceSchedule.MaxQuantity !== null &&
+        (lineItems[0].Product as BuyerProduct).PriceSchedule.MaxQuantity !==
+          null &&
         this.totalQtyToAdd + qtyInCart >
-          lineItems[0].Product.PriceSchedule.MaxQuantity
+          (lineItems[0].Product as BuyerProduct).PriceSchedule.MaxQuantity
       ) {
-        this.errorMsg = `Maximum quantity reached (${lineItems[0].Product.PriceSchedule.MaxQuantity}).  ${qtyInCart} currently in cart.`
+        this.errorMsg = `Maximum quantity reached (${
+          (lineItems[0].Product as BuyerProduct).PriceSchedule.MaxQuantity
+        }).  ${qtyInCart} currently in cart.`
         return false
       }
     } else {
@@ -184,20 +212,24 @@ export class OCMGridSpecForm {
         if (
           li.Quantity !== 0 &&
           li.Quantity !== null &&
-          li.Quantity + qtyInCart < li.Product.PriceSchedule.MinQuantity
+          li.Quantity + qtyInCart <
+            (li.Product as BuyerProduct).PriceSchedule.MinQuantity
         ) {
           this.errorMsg = `Minimum quantity not reached.  ${qtyInCart} in cart, ${
-            li.Product.PriceSchedule.MinQuantity - qtyInCart
+            (li.Product as BuyerProduct).PriceSchedule.MinQuantity - qtyInCart
           } of this product option are needed.`
           return false
         }
         if (
-          li.Product.PriceSchedule.MaxQuantity !== null &&
+          (li.Product as BuyerProduct).PriceSchedule.MaxQuantity !== null &&
           li.Quantity !== 0 &&
           li.Quantity !== null &&
-          li.Quantity + qtyInCart > li.Product.PriceSchedule.MaxQuantity
+          li.Quantity + qtyInCart >
+            (li.Product as BuyerProduct).PriceSchedule.MaxQuantity
         ) {
-          this.errorMsg = `Maximum quantity reached (${li.Product.PriceSchedule.MaxQuantity}).  ${qtyInCart} currently in cart.`
+          this.errorMsg = `Maximum quantity reached (${
+            (li.Product as BuyerProduct).PriceSchedule.MaxQuantity
+          }).  ${qtyInCart} currently in cart.`
           return false
         }
       }
@@ -294,11 +326,25 @@ export class OCMGridSpecForm {
     return true
   }
 
-  getUnitPrice(qty: number, specs: GridSpecOption[]): number {
+  getUnitPrice(
+    qty: number,
+    specs: GridSpecOption[],
+    totalQtyToAdd?: number,
+    useCumulativeQty?: boolean
+  ): number {
     if (!this.priceBreaks?.length) return
+    const lineItemsOfCurrentProductInCartQty: number = this.context.order.cart
+      .get()
+      ?.Items?.filter((i) => i.ProductID === this.product?.ID)
+      ?.map((li) => li.Quantity)
+      ?.reduce((acc, curr) => acc + curr, 0)
+    const quantityOrCumulativeQuantity = useCumulativeQty
+      ? totalQtyToAdd + lineItemsOfCurrentProductInCartQty
+      : qty
     const startingBreak = _minBy(this.priceBreaks, 'Quantity')
     const selectedBreak = this.priceBreaks.reduce((current, candidate) => {
-      return candidate.Quantity > current.Quantity && candidate.Quantity <= qty
+      return candidate.Quantity > current.Quantity &&
+        candidate.Quantity <= quantityOrCumulativeQuantity
         ? candidate
         : current
     }, startingBreak)
@@ -307,10 +353,17 @@ export class OCMGridSpecForm {
     return selectedBreak.Price + totalMarkup
   }
 
-  getLineTotal(qty: number, specs: GridSpecOption[]): number {
+  getLineTotal(
+    qty: number,
+    specs: GridSpecOption[],
+    totalQtyToAdd?: number,
+    useCumulativeQty?: boolean
+  ): number {
+    const quantityOrCumulativeQuantity = useCumulativeQty ? totalQtyToAdd : qty
     if (qty > 0) {
       if (this.priceBreaks?.length) {
-        const basePrice = qty * this.priceBreaks[0].Price
+        const basePrice =
+          quantityOrCumulativeQuantity * this.priceBreaks[0].Price
         this.percentSavings = this.productDetailService.getPercentSavings(
           this.price,
           basePrice
@@ -319,14 +372,15 @@ export class OCMGridSpecForm {
       return this.productDetailService.getGridLineItemPrice(
         this.priceBreaks,
         specs,
-        qty
+        qty,
+        totalQtyToAdd
       )
     }
     return 0
   }
 
   async addToCart(): Promise<void> {
-    const lineItems = this.lineItems.filter((li) => li.Quantity > 0)
+    const lineItems = this.lineItems.filter((li: HSLineItem) => li.Quantity > 0)
     try {
       this.isAddingToCart = true
       await this.context.order.cart.addMany(lineItems)

--- a/src/UI/Buyer/src/app/components/products/product-details/product-detail.service.ts
+++ b/src/UI/Buyer/src/app/components/products/product-details/product-detail.service.ts
@@ -43,13 +43,14 @@ export class ProductDetailService {
   getGridLineItemPrice(
     priceBreaks: PriceBreak[],
     specs: GridSpecOption[],
-    quantity: number
+    quantity: number,
+    totalQtyOfItem?: number
   ): number {
     if (!priceBreaks?.length) return
     const startingBreak = _minBy(priceBreaks, 'Quantity')
     const selectedBreak = priceBreaks.reduce((current, candidate) => {
       return candidate.Quantity > current.Quantity &&
-        candidate.Quantity <= quantity
+        candidate.Quantity <= (totalQtyOfItem || quantity)
         ? candidate
         : current
     }, startingBreak)

--- a/src/UI/Buyer/src/app/components/products/product-details/product-details.component.ts
+++ b/src/UI/Buyer/src/app/components/products/product-details/product-details.component.ts
@@ -1,6 +1,11 @@
 import { Component, Input, OnInit } from '@angular/core'
 import { faTimes, faListUl, faTh } from '@fortawesome/free-solid-svg-icons'
-import { Spec, PriceBreak, SpecOption, Suppliers } from 'ordercloud-javascript-sdk'
+import {
+  Spec,
+  PriceBreak,
+  SpecOption,
+  Suppliers,
+} from 'ordercloud-javascript-sdk'
 import { PriceSchedule } from 'ordercloud-javascript-sdk'
 import {
   HSLineItem,
@@ -73,7 +78,7 @@ export class OCMProductDetails implements OnInit {
     private specFormService: SpecFormService,
     private context: ShopperContextService,
     private productDetailService: ProductDetailService,
-    private toastrService: ToastrService,
+    private toastrService: ToastrService
   ) {}
 
   @Input() set product(superProduct: SuperHSProduct) {
@@ -91,6 +96,7 @@ export class OCMProductDetails implements OnInit {
     this.setSupplier(this._product.DefaultSupplierID)
     this.setPageTitle()
     this.populateInactiveVariants(superProduct)
+    this.showGrid = superProduct?.PriceSchedule?.UseCumulativeQuantity
   }
 
   ngOnInit(): void {

--- a/src/UI/Buyer/src/app/components/products/quantity-input/quantity-input.component.ts
+++ b/src/UI/Buyer/src/app/components/products/quantity-input/quantity-input.component.ts
@@ -28,7 +28,7 @@ export class OCMQuantityInput implements OnInit, OnChanges {
   @Input() product: HSMeProduct
   @Input() selectedVariant: HSVariant
   @Input() li: HSLineItem
-  @Input() groupedLis: HSLineItem[]
+  @Input() groupedLineItems: HSLineItem[]
   @Input() variantInventory?: number
   @Input() variantID: string
   @Input() isAddingToCart: boolean
@@ -118,13 +118,13 @@ export class OCMQuantityInput implements OnInit, OnChanges {
     if (!this.existingQty) {
       this.emit(this.form.get('quantity').value)
     }
-    if (this.groupedLis && this.li) {
+    if (this.groupedLineItems && this.li) {
       // Filter through the lis down to ProductIDs matching the qty inputs li.Product.ID
-      this.cumulativeQuantity = this.groupedLis
+      this.cumulativeQuantity = this.groupedLineItems
         .filter((li) => li.Product?.ID === this.li?.Product?.ID)
         .map((f) => f.Quantity)
         .reduce((acc, curr) => acc + curr)
-      this.qtyPreUpdate = this.groupedLis.find(
+      this.qtyPreUpdate = this.groupedLineItems.find(
         (li) => li.ID === this.li.ID
       ).Quantity
     }

--- a/src/UI/Buyer/src/app/components/products/quantity-input/quantity-input.component.ts
+++ b/src/UI/Buyer/src/app/components/products/quantity-input/quantity-input.component.ts
@@ -10,7 +10,12 @@ import {
 import { FormGroup, Validators, FormControl } from '@angular/forms'
 import { PriceSchedule } from 'ordercloud-javascript-sdk'
 import { Router } from '@angular/router'
-import { HeadStartSDK, HSMeProduct, HSVariant } from '@ordercloud/headstart-sdk'
+import {
+  HeadStartSDK,
+  HSLineItem,
+  HSMeProduct,
+  HSVariant,
+} from '@ordercloud/headstart-sdk'
 import { ShopperContextService } from 'src/app/services/shopper-context/shopper-context.service'
 import { QtyChangeEvent } from 'src/app/models/product.types'
 
@@ -22,6 +27,8 @@ export class OCMQuantityInput implements OnInit, OnChanges {
   @Input() priceSchedule: PriceSchedule
   @Input() product: HSMeProduct
   @Input() selectedVariant: HSVariant
+  @Input() li: HSLineItem
+  @Input() groupedLis: HSLineItem[]
   @Input() variantInventory?: number
   @Input() variantID: string
   @Input() isAddingToCart: boolean
@@ -39,7 +46,9 @@ export class OCMQuantityInput implements OnInit, OnChanges {
   inventory: number
   min: number
   max: number
+  cumulativeQuantity: number
   disabled = false
+  qtyPreUpdate: number
 
   constructor(private router: Router, private context: ShopperContextService) {}
 
@@ -109,6 +118,16 @@ export class OCMQuantityInput implements OnInit, OnChanges {
     if (!this.existingQty) {
       this.emit(this.form.get('quantity').value)
     }
+    if (this.groupedLis && this.li) {
+      // Filter through the lis down to ProductIDs matching the qty inputs li.Product.ID
+      this.cumulativeQuantity = this.groupedLis
+        .filter((li) => li.Product?.ID === this.li?.Product?.ID)
+        .map((f) => f.Quantity)
+        .reduce((acc, curr) => acc + curr)
+      this.qtyPreUpdate = this.groupedLis.find(
+        (li) => li.ID === this.li.ID
+      ).Quantity
+    }
   }
 
   quantityChangeListener(): void {
@@ -142,20 +161,41 @@ export class OCMQuantityInput implements OnInit, OnChanges {
         .get()
         ?.Items?.filter((i) => i.ProductID === this.product?.ID)
         ?.find((p) => p.Variant?.ID === this.selectedVariant?.ID)
-      if (productInCart) {
+      if (
+        productInCart &&
+        !this.product?.PriceSchedule?.UseCumulativeQuantity
+      ) {
         if (qty + productInCart.Quantity > this.max) {
           this.errorMsg = `The maximum is ${this.max} and your cart has ${productInCart.Quantity}.`
           return false
         }
         qty = qty + productInCart.Quantity
       }
+      if (productInCart && this.product?.PriceSchedule?.UseCumulativeQuantity) {
+        if (qty + this.cumulativeQuantity > this.max) {
+          this.errorMsg = `The maximum is ${this.max} and your cart has ${productInCart.Quantity}.`
+          return false
+        }
+        qty = qty + this.cumulativeQuantity
+      }
     }
     if (isNaN(qty)) {
       this.errorMsg = 'Please Enter a Quantity'
       return false
     }
-    if (qty < this.min || qty > this.max) {
+    if (
+      (!this.product?.PriceSchedule?.UseCumulativeQuantity && qty < this.min) ||
+      qty > this.max
+    ) {
       this.errorMsg = `Please order a quantity between ${this.min}-${this.max}.`
+      return false
+    }
+    if (
+      this.product?.PriceSchedule?.UseCumulativeQuantity &&
+      (this.cumulativeQuantity - this.qtyPreUpdate + qty < this.min ||
+        this.cumulativeQuantity - this.qtyPreUpdate + qty > this.max)
+    ) {
+      this.errorMsg = `Please order a total quantity between ${this.min}-${this.max}.`
       return false
     }
     if (qty > this.inventory) {


### PR DESCRIPTION

## Description
### This is a port over from [SEB-1563](https://four51.atlassian.net/browse/SEB-1563)
- First off, in relation to SEB-1566 (no HDS ticket)  - the product detail page will now default to grid ordering view if UseCumulativeQuantity is true
- Other support for UseCumulativeQuantity=true in these changes pertain to Unit Price calculation as well as LineTotal calculation. If UseCumulativeQuantity is true, we are now checking what is in the cart and combining those line quantities with the form line quantities to calculate the unit price (for price break support), and then also using the combined number for validation.

For Reference: [HDS-296](https://four51.atlassian.net/browse/HDS-296) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
