### PR TITLE
HDS-295 Seed updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,52 +90,93 @@ Your backend middleware is configured and all your resources have been provision
 
 Once your organization has been seeded and your applications are configured you'll want to make sure everything is working well.
 
-First, fire up all three applications
+First, deploy the applications or run them locally:
 * [Middleware](./src/Middleware/README.md)
 * [Seller](./src/UI/Seller/README.md)
 * [Buyer](./src/Buyer/README.md)
 
-Then, follow these steps. Our goal is to get to the point where our buyer user can add a product to their cart.
+The goal of this section is to show what steps are required to create a buyer experience on the buyer application. IE allowing a buyer user to browse and shop products and add them to their cart.
+
+Overview of what we will accomplish
+1. Create a Supplier and a Supplier User
+2. Create a Buyer and a Buyer User
+3. Create a Product and define product visibility to the User
+
+> Note: You will have three logins by the end of this process - make sure to keep track of them:
+> 1. Admin User Login
+> 2. Supplier User Login
+> 3. Buyer user Login
+
+#### Step 1: Create Supplier(s)
+
+On the OrderCloud platform, Suppliers are  an organization type used in indirect supply chain scenarios. 
+
+In the HeadStart application, Suppliers are responsible for creating products so we will first need to create suppliers.
+
 1. Open your admin application and sign in with your initial admin user credentials
-2. Navigate to the "Suppliers" tab - suppliers are responsible for creating products so we will need to do that first
-3. Click "Create New supplier". Fill in the required details and create a new supplier.
-4. Within that supplier click "Supplier Addresses"
-5. Click "Create New Supplier Address", fill in the details, and create a new address. Use an actual address or it will fail address validation
-6. Go back to the supplier detail page and then click "Users"
-7. Note that there is already a user here with an ID that starts with `dev_` this user exists so that the middleware can act on behalf of it if needed to act as that supplier. Do not delete this user.
-8. Click "Create New User" and fill out the details. Make sure to set "Active" true and for now assign all permissions to the user.
-9. If you have [emails set up](#sendgrid-email-configuration) you can use the "forgot password" feature to set a password for the supplier user otherwise set the password for that user in the portal
+2. Navigate to the "Suppliers" tab
+3. Click "Create New supplier"
+4. Fill in the required details and create a new Supplier
+5. Within that supplier click "Supplier Addresses"
+6. Click "Create New Supplier Address"
+   1. Fill in the details, and create a new address. **Use an actual address or it will fail address validation**
+7. Go back to the supplier detail page by using the breadcrumbs
+8. Click "Users"
+   1. Note that there is already a user here with an ID that starts with `dev_` this user exists so that the middleware can act on behalf of it if needed to act as that supplier. **Do not delete this user**
+9.  Click "Create New User"
+    1.  and fill out the details
+    2.  Make sure to set "Active" true
+    3.  Assign all permissions to the user
+    4.  If you have [emails set up](#sendgrid-email-configuration) you can use the "forgot password" feature to set a password for the supplier user otherwise set the password for that user in the portal
+
+
+#### Step 2: Create Catalog(s)
+
 10. Next click on "Buyers"
 11. Click "Default HeadStart Buyer"
 12. Click "Catalogs"
-13. Click "Create New Catalog" this will ultimately be the container that holds our products
-14. Go back to the buyer detail page
-15. Click "Buyer Locations"
-16. Click "Create New Buyer Location" - fill in the details and use a real address so it passes valiation. At the bottom assign our previously created Catalog to that buyer location.
-17. Go back to the buyer detail page
+13. Click "Create New Catalog"
+    1.  this will be the container that holds our products
+14. Go back to the buyer detail page by using the breadcrumbs
+15. Click "Buyer Groups"
+16. Click "Create New Buyer Group"
+    1.  Fill in the details and use a real address so it passes valiation
+    2.  At the bottom assign our previously created Catalog to that buyer group
+17. Go back to the buyer detail page by using the breadcrumbs
 18. Click "Users"
-19. Click "Create a New User" - make sure Active is set to true
-20. If you have [emails set up](#sendgrid-email-configuration) you can use the "forgot password" feature to set a password for the buyer user on your buyer application otherwise set the password for that user in the portal
-21. At this point we've done all we can as a seller user. We now need to log in to the admin application as a supplier user to create our product
-22. Log out of seller application
-23. Log in as your previously created supplier user
-24. Click on "Products"
-25. Click "Create New Product" - select "Standard Product". Enter required fields - sections marked with a red asterisk in Product tab and Pricing tab
-26. Now that the product is created our seller needs to define the visibility
-27. Log out of seller application
-28. Log in as your initial admin user
-29. Click on "Products"
-30. Click on the previously created product
-31. Click the "Buyer Visibility" tab
-32. Click "Edit" on "Default Headstart Buyer"
-33. Click the toggle to make the product visible to our previously created catalog
-34. Click "Save"
-35. Go to your buyer application
-36. Sign in as your buyer user
-37. Click on "Products"
-38. You should see your product in the list, click it.
-39. Click "Add to cart"
-40. Click the cart icon
+19. Click "Create a New User"
+    1.  Make sure Active is set to true
+    2.  If you have [emails set up](#sendgrid-email-configuration) you can use the "forgot password" feature to set a password for the buyer user on your buyer application
+20. At this point we've done all we can as a seller user. We now need to log in to the admin application as a supplier user to create our product
+21. Log out of the seller application
+22. Log in as your previously created supplier user
+
+#### Step 3: Create Product(s)
+
+23. Click on "Products"
+24. Click "Create New Product" - select "Standard Product"
+    1.  Enter the required fields - Required fields are marked with a red asterisk
+    2.  Make sure you set your product to Active
+    3.  Click Create to save the product
+25. Now that the product is created our seller needs to define the visibility
+26. Log out of seller application
+27. Log in as your initial admin user
+28. Click on "Products"
+29. Click on the previously created product
+30. Click the "Buyer Visibility" tab
+31. Click "Edit" on "Default Headstart Buyer"
+32. Click the toggle to make the product visible to our previously created catalog
+33. Click "Save"
+
+#### Step 4: Review Your Buyer App Experience
+34. Go to your buyer application
+35. Sign in as your buyer user
+36. Click on "Products" or shop and navigate through the category hierarchy
+37. You should see your product in the list!
+38. You can then add your product to your cart in 2 ways:
+    1.  Click into the product and then click "Add to Cart" on the product detail page
+    2.  Click the add to cart button on the product grid page for any product you want added to your cart
+39. Navigate to your cart and you should see the product display, VOILA!
 
 Congrats! Hopefully you didn't get any errors and understand a little bit more about how everything is connected. If you did encounter errors please capture the details and submit an issue on Github.
 

--- a/src/Middleware/integrations/ordercloud.integrations.exchangerates/AppSettings.cs
+++ b/src/Middleware/integrations/ordercloud.integrations.exchangerates/AppSettings.cs
@@ -1,7 +1,0 @@
-﻿namespace ordercloud.integrations.exchangerates
-{
-    public class ExchangeRatesSettings
-    {
-        public string ConnectionString { get; set; }
-    }
-}

--- a/src/Middleware/integrations/ordercloud.integrations.library/blobs/BlobSettings.cs
+++ b/src/Middleware/integrations/ordercloud.integrations.library/blobs/BlobSettings.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace ordercloud.integrations.library
 {
     public class BlobSettings

--- a/src/Middleware/integrations/ordercloud.integrations.library/cosmos-repo/CosmosExtensions.cs
+++ b/src/Middleware/integrations/ordercloud.integrations.library/cosmos-repo/CosmosExtensions.cs
@@ -12,6 +12,13 @@ namespace ordercloud.integrations.library
                                                      string databaseName,
                                                      List<ContainerInfo> containers)
         {
+            if(endpointUrl == null || primaryKey == null || databaseName == null)
+            {
+                // allow server to be started up without these settings
+                // in case they're just trying to seed their environment
+                // in the future we'll remove this in favor of centralized seeding capability
+                return services;
+            }
             CosmosClient client = new CosmosClient(endpointUrl, primaryKey);
             var cosmosDbClientFactory = new CosmosDbContainerFactory(client, databaseName, containers);
 

--- a/src/Middleware/integrations/ordercloud.integrations.library/extensions/ServiceCollectionExtensions.cs
+++ b/src/Middleware/integrations/ordercloud.integrations.library/extensions/ServiceCollectionExtensions.cs
@@ -50,6 +50,13 @@ namespace ordercloud.integrations.library
             where TQuery : class
             where TModel : class
         {
+            if(config.DatabaseName == null || config.EndpointUri == null || config.PrimaryKey == null)
+            {
+                // allow server to be started up without these settings
+                // in case they're just trying to seed their environment
+                // in the future we'll remove this in favor of centralized seeding capability
+                return services;
+            }
             var settings = new CosmosStoreSettings(config.DatabaseName, config.EndpointUri, config.PrimaryKey,
                 new ConnectionPolicy
                 {

--- a/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
@@ -11,11 +11,12 @@ namespace Headstart.API.Commands
 {
     public interface IHSBuyerLocationCommand
     {
-        Task<HSBuyerLocation> Create(string buyerID, HSBuyerLocation buyerLocation, string token);
-        Task<HSBuyerLocation> Get(string buyerID, string buyerLocationID, string token);
-        Task<HSBuyerLocation> Save(string buyerID, string buyerLocationID, HSBuyerLocation buyerLocation, string token, bool isSeedEnv = false);
-        Task Delete(string buyerID, string buyerLocationID, string token);
-        Task CreateSinglePermissionGroup(string token, string buyerLocationID, string permissionGroupID);
+        Task<HSBuyerLocation> Get(string buyerID, string buyerLocationID);
+        Task<HSBuyerLocation> Create(string buyerID, HSBuyerLocation buyerLocation);
+        Task<HSBuyerLocation> Save(string buyerID, string buyerLocationID, HSBuyerLocation buyerLocation);
+        Task<HSBuyerLocation> Save(string buyerID, string buyerLocationID, HSBuyerLocation buyerLocation, string token, IOrderCloudClient oc = null);
+        Task Delete(string buyerID, string buyerLocationID);
+        Task CreateSinglePermissionGroup(string buyerLocationID, string permissionGroupID);
     }
 
     public class HSBuyerLocationCommand : IHSBuyerLocationCommand
@@ -27,10 +28,11 @@ namespace Headstart.API.Commands
             _settings = settings;
             _oc = oc;
         }
-        public async Task<HSBuyerLocation> Get(string buyerID, string buyerLocationID, string token)
+
+        public async Task<HSBuyerLocation> Get(string buyerID, string buyerLocationID)
         {
-            var buyerAddress = await _oc.Addresses.GetAsync<HSAddressBuyer>(buyerID, buyerLocationID, accessToken: token);
-            var buyerUserGroup = await _oc.UserGroups.GetAsync<HSLocationUserGroup>(buyerID, buyerLocationID, accessToken: token);
+            var buyerAddress = await _oc.Addresses.GetAsync<HSAddressBuyer>(buyerID, buyerLocationID);
+            var buyerUserGroup = await _oc.UserGroups.GetAsync<HSLocationUserGroup>(buyerID, buyerLocationID);
             return new HSBuyerLocation
             {
                 Address = buyerAddress,
@@ -38,16 +40,21 @@ namespace Headstart.API.Commands
             };
         }
 
-        public async Task<HSBuyerLocation> Create(string buyerID, HSBuyerLocation buyerLocation, string token)
+        public async Task<HSBuyerLocation> Create(string buyerID, HSBuyerLocation buyerLocation)
+        {
+            return await Create(buyerID, buyerLocation, null, _oc);
+        }
+
+        public async Task<HSBuyerLocation> Create(string buyerID, HSBuyerLocation buyerLocation, string token, IOrderCloudClient ocClient)
         {
             var buyerLocationID = CreateBuyerLocationID(buyerID, buyerLocation.Address.ID);
             buyerLocation.Address.ID = buyerLocationID;
-            var buyerAddress = await _oc.Addresses.CreateAsync<HSAddressBuyer>(buyerID, buyerLocation.Address, accessToken: token);
+            var buyerAddress = await ocClient.Addresses.CreateAsync<HSAddressBuyer>(buyerID, buyerLocation.Address, accessToken: token);
 
             buyerLocation.UserGroup.ID = buyerAddress.ID;
-            var buyerUserGroup = await _oc.UserGroups.CreateAsync<HSLocationUserGroup>(buyerID, buyerLocation.UserGroup, accessToken: token);
-            await CreateUserGroupAndAssignments(buyerID, buyerAddress.ID, token);
-            await CreateLocationUserGroupsAndApprovalRule(buyerAddress.ID, buyerAddress.AddressName, token);
+            var buyerUserGroup = await ocClient.UserGroups.CreateAsync<HSLocationUserGroup>(buyerID, buyerLocation.UserGroup, accessToken: token);
+            await CreateUserGroupAndAssignments(buyerID, buyerAddress.ID, token, ocClient);
+            await CreateLocationUserGroupsAndApprovalRule(buyerAddress.ID, buyerAddress.AddressName, token, ocClient);
 
             return new HSBuyerLocation
             {
@@ -75,7 +82,7 @@ namespace Headstart.API.Commands
             return buyerID + "-" + idInRequest.Replace("-", "_");
         }
 
-        public async Task CreateUserGroupAndAssignments(string buyerID, string buyerLocationID, string token)
+        public async Task CreateUserGroupAndAssignments(string buyerID, string buyerLocationID, string token, IOrderCloudClient ocClient)
         {
             var assignment = new AddressAssignment
             {
@@ -84,20 +91,26 @@ namespace Headstart.API.Commands
                 IsBilling = true,
                 IsShipping = true
             };
-            await _oc.Addresses.SaveAssignmentAsync(buyerID, assignment, accessToken: token);
+            await ocClient.Addresses.SaveAssignmentAsync(buyerID, assignment, accessToken: token);
         }
 
-        public async Task<HSBuyerLocation> Save(string buyerID, string buyerLocationID, HSBuyerLocation buyerLocation, string token, bool isSeedEnv = false)
+        public async Task<HSBuyerLocation> Save(string buyerID, string buyerLocationID, HSBuyerLocation buyerLocation)
+        {
+            // not being called by seed endpoint - use stored ordercloud client and stored admin token
+            return await Save(buyerID, buyerLocationID, buyerLocation, null, _oc);
+        }
+
+        public async Task<HSBuyerLocation> Save(string buyerID, string buyerLocationID, HSBuyerLocation buyerLocation, string token, IOrderCloudClient ocClient)
         {
             buyerLocation.Address.ID = buyerLocationID;
             buyerLocation.UserGroup.ID = buyerLocationID;
             UserGroup existingLocation = null;
             try
             {
-                existingLocation = await _oc.UserGroups.GetAsync(buyerID, buyerLocationID, token);
+                existingLocation = await ocClient.UserGroups.GetAsync(buyerID, buyerLocationID, token);
             } catch (Exception e) { } // Do nothing if not found
-            var updatedBuyerAddress = _oc.Addresses.SaveAsync<HSAddressBuyer>(buyerID, buyerLocationID, buyerLocation.Address, accessToken: token);
-            var updatedBuyerUserGroup = _oc.UserGroups.SaveAsync<HSLocationUserGroup>(buyerID, buyerLocationID, buyerLocation.UserGroup, accessToken: token);
+            var updatedBuyerAddress = ocClient.Addresses.SaveAsync<HSAddressBuyer>(buyerID, buyerLocationID, buyerLocation.Address, accessToken: token);
+            var updatedBuyerUserGroup = ocClient.UserGroups.SaveAsync<HSLocationUserGroup>(buyerID, buyerLocationID, buyerLocation.UserGroup, accessToken: token);
             var location = new HSBuyerLocation
             {
                 Address = await updatedBuyerAddress,
@@ -105,29 +118,30 @@ namespace Headstart.API.Commands
             };
             if (existingLocation == null)
 			{
-                var assignments = CreateUserGroupAndAssignments(buyerID, buyerLocationID, token);
-                var groups = CreateLocationUserGroupsAndApprovalRule(buyerLocationID, buyerLocation.Address.AddressName, token, isSeedEnv);
+                var assignments = CreateUserGroupAndAssignments(buyerID, buyerLocationID, token, ocClient);
+                var groups = CreateLocationUserGroupsAndApprovalRule(buyerLocationID, buyerLocation.Address.AddressName, token, ocClient);
                 await Task.WhenAll(assignments, groups);
             }
             return location;
         }
 
-        public async Task Delete(string buyerID, string buyerLocationID, string token)
+        public async Task Delete(string buyerID, string buyerLocationID)
         {
-            var deleteAddressReq = _oc.Addresses.DeleteAsync(buyerID, buyerLocationID, accessToken: token);
-            var deleteUserGroupReq = _oc.UserGroups.DeleteAsync(buyerID, buyerLocationID, accessToken: token);
+            var deleteAddressReq = _oc.Addresses.DeleteAsync(buyerID, buyerLocationID);
+            var deleteUserGroupReq = _oc.UserGroups.DeleteAsync(buyerID, buyerLocationID);
             await Task.WhenAll(deleteAddressReq, deleteUserGroupReq);
         }
 
-        public async Task CreateLocationUserGroupsAndApprovalRule(string buyerLocationID, string locationName, string token, bool isSeedEnv = false)
+        public async Task CreateLocationUserGroupsAndApprovalRule(string buyerLocationID, string locationName, string accessToken, IOrderCloudClient ocClient)
         {
             var buyerID = buyerLocationID.Split('-').First();
-            var AddUserTypeRequests = HSUserTypes.BuyerLocation().Select(userType => AddUserTypeToLocation(token, buyerLocationID, userType));
+            var AddUserTypeRequests = HSUserTypes.BuyerLocation().Select(userType => AddUserTypeToLocation(buyerLocationID, userType, accessToken, ocClient));
             await Task.WhenAll(AddUserTypeRequests);
-            if(!isSeedEnv)
+            var isSeedingEnvironment = ocClient != null;
+            if(!isSeedingEnvironment)
             {
-                var approvingGroupID = $"{buyerLocationID}-{UserGroupSuffix.OrderApprover.ToString()}";
-                await _oc.ApprovalRules.CreateAsync(buyerID, new ApprovalRule()
+                var approvingGroupID = $"{buyerLocationID}-{UserGroupSuffix.OrderApprover}";
+                await ocClient.ApprovalRules.CreateAsync(buyerID, new ApprovalRule()
                 {
                     ID = buyerLocationID,
                     ApprovingGroupID = approvingGroupID,
@@ -138,17 +152,29 @@ namespace Headstart.API.Commands
             }
         }
 
-        public async Task CreateSinglePermissionGroup(string token, string buyerLocationID, string permissionGroupID)
+        public async Task CreateSinglePermissionGroup(string buyerLocationID, string permissionGroupID)
         {
             var permissionGroup = HSUserTypes.BuyerLocation().Find(userType => permissionGroupID.Contains(userType.UserGroupIDSuffix));
-            await AddUserTypeToLocation(token, buyerLocationID, permissionGroup);
+            await AddUserTypeToLocation(buyerLocationID, permissionGroup);
         }
 
-        public async Task AddUserTypeToLocation(string token, string buyerLocationID, HSUserType hsUserType)
+        public async Task AddUserTypeToLocation(string buyerLocationID, HSUserType hsUserType)
         {
+            // not being called by seed endpoint - use stored ordercloud client and stored admin token
+            await AddUserTypeToLocation(buyerLocationID, hsUserType, null, _oc);
+        }
+
+        public async Task AddUserTypeToLocation(string buyerLocationID, HSUserType hsUserType, string accessToken, IOrderCloudClient oc)
+        {
+            // if we're seeding then use the passed in oc client
+            // to support multiple environments and ease of setup for new orgs
+            // else used the configured client
+            var token = oc == null ? null : accessToken;
+            var ocClient = oc ?? _oc;
+
             var buyerID = buyerLocationID.Split('-').First();
             var userGroupID = $"{buyerLocationID}-{hsUserType.UserGroupIDSuffix}";
-            await _oc.UserGroups.CreateAsync(buyerID, new PartialUserGroup()
+            await ocClient.UserGroups.CreateAsync(buyerID, new PartialUserGroup()
             {
                 ID = userGroupID,
                 Name = hsUserType.UserGroupName,
@@ -161,7 +187,7 @@ namespace Headstart.API.Commands
             }, token);
             foreach (var customRole in hsUserType.CustomRoles)
             {
-                await _oc.SecurityProfiles.SaveAssignmentAsync(new SecurityProfileAssignment()
+                await ocClient.SecurityProfiles.SaveAssignmentAsync(new SecurityProfileAssignment()
                 {
                     BuyerID = buyerID,
                     UserGroupID = userGroupID,
@@ -169,7 +195,5 @@ namespace Headstart.API.Commands
                 }, token);
             }
         }
-
-
     }
 }

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
@@ -11,7 +11,6 @@ using System.IO;
 using Headstart.Common.Services;
 using Headstart.Common;
 using ordercloud.integrations.exchangerates;
-using Headstart.Common.Models;
 using OrderCloud.Catalyst;
 using Headstart.Common.Services.Portal.Models;
 
@@ -414,7 +413,13 @@ namespace Headstart.API.Commands
         private Task<ApiClient> GetClientRequest(List<ApiClient> existingClients, ApiClient client, string token)
         {
             var match = existingClients.Find(c => c.AppName == client.AppName);
-            return match != null ? _oc.ApiClients.SaveAsync(match.ID, client, token) : _oc.ApiClients.CreateAsync(client, token);
+            if(match == null)
+            {
+                return _oc.ApiClients.CreateAsync(client, token);
+            }
+
+            client.ClientSecret = match.ClientSecret; // don't overwrite client secret
+            return _oc.ApiClients.SaveAsync(match.ID, client, token);
         }
 
         private async Task CreateMessageSenders(EnvironmentSeed seed, string accessToken)

--- a/src/Middleware/src/Headstart.API/Controllers/BuyerController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/BuyerController.cs
@@ -27,21 +27,21 @@ namespace Headstart.Common.Controllers
         [HttpPost, OrderCloudUserAuth(ApiRole.BuyerAdmin)]
         public async Task<SuperHSBuyer> Create([FromBody] SuperHSBuyer buyer)
         {
-            return await _command.Create(buyer, UserContext.AccessToken);
+            return await _command.Create(buyer);
         }
 
         [DocName("PUT Headstart Buyer")]
         [HttpPut, Route("{buyerID}"), OrderCloudUserAuth(ApiRole.BuyerAdmin)]
         public async Task<SuperHSBuyer> Put([FromBody] SuperHSBuyer superBuyer, string buyerID)
         {
-            return await _command.Update(buyerID, superBuyer, UserContext.AccessToken);
+            return await _command.Update(buyerID, superBuyer);
         }
 
         [DocName("GET Headstart Buyer")]
         [HttpGet, Route("{buyerID}"), OrderCloudUserAuth(ApiRole.BuyerAdmin)]
         public async Task<SuperHSBuyer> Get(string buyerID)
         {
-            return await _command.Get(buyerID, UserContext.AccessToken);
+            return await _command.Get(buyerID);
         }
     }
 }

--- a/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
@@ -30,24 +30,21 @@ namespace Headstart.Common.Controllers
         [HttpGet, Route("{buyerID}/{buyerLocationID}"), OrderCloudUserAuth(ApiRole.UserGroupAdmin, ApiRole.AddressAdmin)]
         public async Task<HSBuyerLocation> Get(string buyerID, string buyerLocationID)
         {
-            return await _buyerLocationCommand.Get(buyerID, buyerLocationID, UserContext.AccessToken);
+            return await _buyerLocationCommand.Get(buyerID, buyerLocationID);
         }
 
         [DocName("POST a Buyer Location")]
         [HttpPost, Route("{buyerID}"), OrderCloudUserAuth(ApiRole.UserGroupAdmin, ApiRole.AddressAdmin)]
         public async Task<HSBuyerLocation> Create(string buyerID, [FromBody] HSBuyerLocation buyerLocation)
         {
-            // ocAuth is the token for the organization that is specified in the AppSettings
-            var ocAuth = await _oc.AuthenticateAsync();
-            return await _buyerLocationCommand.Create(buyerID, buyerLocation, ocAuth.AccessToken);
+            return await _buyerLocationCommand.Create(buyerID, buyerLocation);
         }
 
         [DocName("POST a Buyer Location permission group")]
         [HttpPost, Route("{buyerID}/{buyerLocationID}/permissions/{permissionGroupID}"), OrderCloudUserAuth(ApiRole.UserGroupAdmin, ApiRole.AddressAdmin)]
         public async Task CreatePermissionGroup(string buyerID, string buyerLocationID, string permissionGroupID)
         {
-            var ocAuth = await _oc.AuthenticateAsync();
-            await _buyerLocationCommand.CreateSinglePermissionGroup(ocAuth.AccessToken, buyerLocationID, permissionGroupID);
+            await _buyerLocationCommand.CreateSinglePermissionGroup(buyerLocationID, permissionGroupID);
         }
 
         [DocName("PUT a Buyer Location")]
@@ -61,7 +58,7 @@ namespace Headstart.Common.Controllers
         [HttpDelete, Route("{buyerID}/{buyerLocationID}"), OrderCloudUserAuth(ApiRole.UserGroupAdmin, ApiRole.AddressAdmin)]
         public async Task Delete(string buyerID, string buyerLocationID)
         {
-            await _buyerLocationCommand.Delete(buyerID, buyerLocationID, UserContext.AccessToken);
+            await _buyerLocationCommand.Delete(buyerID, buyerLocationID);
         }
 
         [DocName("GET List of location permission user groups")]

--- a/src/Middleware/src/Headstart.API/Controllers/EnvironmentSeedController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/EnvironmentSeedController.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Headstart.Models.Misc;
-using ordercloud.integrations.library;
 using Headstart.API.Commands;
 using OrderCloud.Catalyst;
 
@@ -10,12 +9,15 @@ namespace Headstart.Common.Controllers
     public class EnvironmentSeedController : BaseController
     {
         private readonly IEnvironmentSeedCommand _command;
+        private readonly AppSettings _settings;
 
         public EnvironmentSeedController(
-            IEnvironmentSeedCommand command
+            IEnvironmentSeedCommand command,
+            AppSettings settings
         )
         {
             _command = command;
+            _settings = settings;
         }
 
         [HttpPost, Route("seed")]
@@ -27,6 +29,10 @@ namespace Headstart.Common.Controllers
 		[HttpPost, Route("post-staging-restore"), OrderCloudWebhookAuth]
 		public async Task PostStagingRestore()
 		{
+            if(_settings.EnvironmentSettings.Environment == AppEnvironment.Production)
+            {
+                return;
+            }
 			await _command.PostStagingRestore();
 		}
 	}

--- a/src/Middleware/src/Headstart.API/Startup.cs
+++ b/src/Middleware/src/Headstart.API/Startup.cs
@@ -181,7 +181,7 @@ namespace Headstart.API
 
 
             ServicePointManager.DefaultConnectionLimit = int.MaxValue;
-            FlurlHttp.Configure(settings => settings.Timeout = TimeSpan.FromSeconds(_settings.FlurlSettings.TimeoutInSeconds));
+            FlurlHttp.Configure(settings => settings.Timeout = TimeSpan.FromSeconds(_settings.FlurlSettings.TimeoutInSeconds == 0 ? 30 : _settings.FlurlSettings.TimeoutInSeconds));
 
             // This adds retry logic for any api call that fails with a transient error (server errors, timeouts, or rate limiting requests)
             // Will retry up to 3 times using exponential backoff and jitter, a mean of 3 seconds wait time in between retries

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -1,18 +1,17 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using ordercloud.integrations.library;
-using SendGrid.Helpers.Mail;
 using Newtonsoft.Json;
-using System.Text.Json.Serialization;
 using Headstart.Models.Headstart;
-using Headstart.Common;
 using System.Linq;
 
 namespace Headstart.Models.Misc
 {
-    [DocIgnore]
-    public class EnvironmentSeed
-    {
+	[DocIgnore]
+	public class EnvironmentSeed
+	{
+		#region Required settings
+
 		/// <summary>
 		/// The username for logging in to https://portal.ordercloud.io
 		/// </summary>
@@ -36,8 +35,25 @@ namespace Headstart.Models.Misc
 		/// </summary>
 		[Required]
 		[StringLength(100, ErrorMessage = "Password must be at least 8 characters long and maximum 100 characters long", MinimumLength = 8)]
-		[RegularExpression("^(?=.*[a-zA-Z])(?=.*[0-9]).+$", ErrorMessage = "Password must contain at least one letter and one number")]
+		[RegularExpression("^(?=.{10,}$)(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\\W).*$", ErrorMessage = "Password must contain one number, one uppercase letter, one lowercase letter, one special character and have a minimum of 10 characters total")]
 		public string InitialAdminPassword { get; set; }
+
+		/// <summary>
+		/// The url to your hosted middleware endpoint
+		/// needed for webhooks and message senders
+		/// </summary>
+		[Required]
+		public string MiddlewareBaseUrl { get; set; }
+
+		/// <summary>
+		/// Container for OrderCloud Settings
+		/// </summary>
+		[Required]
+		public OrderCloudSeedSettings OrderCloudSettings { get; set; }
+
+		#endregion
+
+		#region Optional settings
 
 		/// <summary>
 		/// Optionally pass in a value if you have an existing organization you would like to seed. If no value is present a new org will be created
@@ -45,6 +61,9 @@ namespace Headstart.Models.Misc
 		/// </summary>
 		public string SellerOrgID { get; set; }
 
+		/// <summary>
+		/// Optionally pass in a seller org name when first creating an organization
+		/// </summary>
 		public string SellerOrgName { get; set; }
 
 		/// <summary>
@@ -63,24 +82,17 @@ namespace Headstart.Models.Misc
 		/// </summary>
 		public string AnonymousShoppingBuyerID { get; set; }
 
-		public string MiddlewareBaseUrl { get; set; }
-
-		/// <summary>
-		/// OrderCloud values that tell us what OC environment to use.
-		/// Environment and WebhookHashKey are the only required fields for seeding.
-		/// Your environment will be either sandbox or production. Your WebhookHashKey can be any string of your choosing.
-		/// </summary>
-		public OrderCloudSeedRequest OrderCloudSettings { get; set; }
-
 		/// <summary>
 		/// An optional object of storage settings for your translations container. 
 		/// If none are provided the seeding funciton will not create a translation file.
-		/// Provide a valid ConnectionString and ContainerNameTranslations to have the seeding function generate your translation file
+		/// Provide a valid ConnectionString to have the seeding function generate your translation file
 		/// </summary>
-		public BlobSettings BlobSettings { get; set; }
+		public BlobSeedSettings BlobSettings { get; set; }
+
+        #endregion
     }
 
-	[DocIgnore]
+    [DocIgnore]
 	public class EnvironmentSeedResponse
     {
 		public string Comments { get; set; }
@@ -90,14 +102,29 @@ namespace Headstart.Models.Misc
 		public Dictionary<string, dynamic> ApiClients { get; set; }
     }
 
-	public class OrderCloudSeedRequest
-	{
+	public class OrderCloudSeedSettings
+    {
+		/// <summary>
+		/// The ordercloud environment
+		/// </summary>
 		[Required]
-		[ValueRange(AllowableValues = new[] { "production", "prod", "sandbox" })]
+		[ValueRange(AllowableValues = new[] { "production", "sandbox" })]
 		public string Environment { get; set; }
+
+		/// <summary>
+		/// Used to secure your webhook endpoints
+		/// provide a secure, non-guessable string
+		/// </summary>
+		[Required, MaxLength(15)]
 		public string WebhookHashKey { get; set; }
-		public string MiddlewareClientID { get; set; }
-		public string MiddlewareClientSecret { get; set; }
+	}
+
+	public class BlobSeedSettings
+    {
+		[Required]
+		public string ConnectionString { get; set; }
+		public string ContainerNameTranslations { get; set; } = "ngx-translate";
+
 	}
 
 	public class OrderCloudEnvironments


### PR DESCRIPTION
## Description
This pull request introduces a few improvements to the seeding process
1. ClientSecret is now preserved on update operations
2. Allows application to build even if no settings are defined so it can be used as a stand-alone seeding application
3. Sets CORS on blob containers to allow all. Fixes issues where app loads and retrieving translation files fail because of CORS errors
4. Add more model validation
5. Increase password complexity to match OrderCloud's [new required standard](https://ordercloud.io/knowledge-base/custom-password-configuration)
6. Update README for validating a correctly seeded environment

For Reference: [HDS-295](https://four51.atlassian.net/browse/HDS-295)

- [x] I have updated the acceptance criteria on the task so that it can be tested
