### PR TITLE
HDS-279 get rid of ExpressionChangedAfterItHasBeenCheckedError

### DIFF
--- a/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.html
+++ b/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.html
@@ -699,7 +699,7 @@
           class="btn btn-link mr-3"
           (click)="handleDiscardChanges()"
           *ngIf="!isCreatingNew"
-          [disabled]="!areChanges"
+          [disabled]="noChanges"
           translate
         >
           ADMIN.PROMOTIONS.DISCARD_CHANGES
@@ -707,7 +707,7 @@
         <button
           class="btn btn-primary"
           type="submit"
-          [disabled]="isSaveBtnDisabled()"
+          [disabled]="isSaveBtnDisabled"
           (click)="handleSave()"
         >
           {{ getSaveBtnText() }}
@@ -822,7 +822,7 @@
             class="btn btn-link mr-3"
             (click)="handleDiscardChanges()"
             *ngIf="!isCreatingNew"
-            [disabled]="!areChanges"
+            [disabled]="noChanges"
             translate
           >
             ADMIN.PROMOTIONS.DISCARD_CHANGES
@@ -831,7 +831,7 @@
             class="btn btn-primary"
             type="submit"
             (click)="handleSave()"
-            [disabled]="isSaveBtnDisabled()"
+            [disabled]="isSaveBtnDisabled"
           >
             {{ getSaveBtnText() }}
           </button>

--- a/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.ts
+++ b/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.ts
@@ -85,6 +85,8 @@ export class PromotionEditComponent implements OnInit, OnChanges {
   faCalendar = faCalendar
   productsCollapsed = true
   currentDateTime: string
+  isSaveBtnDisabled?: boolean = null
+  noChanges?: boolean = !this.areChanges
   constructor(
     public promotionService: PromotionService,
     private ocPromotionService: OcPromotionService,
@@ -98,7 +100,6 @@ export class PromotionEditComponent implements OnInit, OnChanges {
   ngOnInit(): void {
     this.isCreatingNew = this.promotionService.checkIfCreatingNew()
     this.listResources()
-    this.isSaveBtnDisabled()
   }
 
   ngOnChanges(): void {
@@ -261,6 +262,20 @@ export class PromotionEditComponent implements OnInit, OnChanges {
         _get(promotion, 'xp.MaxShipCost'),
         Validators.min(0)
       ),
+    })
+
+    this.resourceForm.valueChanges.subscribe(() => {
+      setTimeout(() => {
+        this.noChanges = !this.areChanges
+        if (!this.areChanges && this.isCreatingNew) {
+          this.isSaveBtnDisabled =
+            this.resourceForm?.status === 'INVALID' || this.dataIsSaving
+        } else if (!this.areChanges && !this.isCreatingNew) {
+          this.isSaveBtnDisabled = true
+        } else {
+          this.isSaveBtnDisabled = null
+        }
+      })
     })
   }
 
@@ -487,16 +502,6 @@ export class PromotionEditComponent implements OnInit, OnChanges {
       this.dataIsSaving,
       this.isCreatingNew
     )
-  }
-
-  isSaveBtnDisabled(): boolean {
-    if (!this.areChanges && this.isCreatingNew) {
-      return this.resourceForm?.status === 'INVALID' || this.dataIsSaving
-    } else if (!this.areChanges && !this.isCreatingNew) {
-      return true
-    } else {
-      return null
-    }
   }
 
   handleClearMinReq(): void {


### PR DESCRIPTION
## Description
This gets rid of an error that I suspect is causing flakey issues on chrome. Ideally wouldn't have to use a set timeout but couldn't find a better way. 

For Reference: [HDS-279](https://four51.atlassian.net/browse/HDS-279)

- [x] I have updated the acceptance criteria on the task so that it can be tested
