### PR TITLE
HDS-363 remove buyerConfigs

### DIFF
--- a/src/UI/Seller/src/app/config/app.config.ts
+++ b/src/UI/Seller/src/app/config/app.config.ts
@@ -12,7 +12,6 @@ export const ocAppConfig: AppConfig = {
   orderCloudApiUrl: environment.orderCloudApiUrl,
   translateBlobUrl: environment.translateBlobUrl,
   blobStorageUrl: environment.blobStorageUrl,
-  superProductFieldsToMonitor: environment.superProductFieldsToMonitor,
   // sellerName is being hard-coded until this is available to store in OrderCloud
   sellerName: environment.sellerName,
   scope: [

--- a/src/UI/Seller/src/app/config/app.config.ts
+++ b/src/UI/Seller/src/app/config/app.config.ts
@@ -12,7 +12,6 @@ export const ocAppConfig: AppConfig = {
   orderCloudApiUrl: environment.orderCloudApiUrl,
   translateBlobUrl: environment.translateBlobUrl,
   blobStorageUrl: environment.blobStorageUrl,
-  buyerConfigs: environment.buyerConfigs,
   superProductFieldsToMonitor: environment.superProductFieldsToMonitor,
   // sellerName is being hard-coded until this is available to store in OrderCloud
   sellerName: environment.sellerName,

--- a/src/UI/Seller/src/app/models/environment.types.ts
+++ b/src/UI/Seller/src/app/models/environment.types.ts
@@ -11,7 +11,6 @@ export interface EnvironmentConfig {
   translateBlobUrl: string
   blobStorageUrl: string
   orderCloudApiUrl: string
-  superProductFieldsToMonitor: string[]
 }
 
 export interface BuyerConfig {
@@ -56,13 +55,6 @@ export interface AppConfig {
 
   // sellerName is being hard-coded until this is available to store in OrderCloud
   sellerName: string
-
-  /**
-   * An array of fields on a product that should be monitored for changes.
-   * If a supplier makes a change to a field within this string array, the product will be deactivated
-   * until a seller reviews the change and approves it.
-   */
-  superProductFieldsToMonitor: string[]
 
   /**
    * An array of security roles that will be requested upon login.

--- a/src/UI/Seller/src/app/models/environment.types.ts
+++ b/src/UI/Seller/src/app/models/environment.types.ts
@@ -11,7 +11,6 @@ export interface EnvironmentConfig {
   translateBlobUrl: string
   blobStorageUrl: string
   orderCloudApiUrl: string
-  buyerConfigs: Record<string, BuyerConfig>
   superProductFieldsToMonitor: string[]
 }
 
@@ -57,9 +56,6 @@ export interface AppConfig {
 
   // sellerName is being hard-coded until this is available to store in OrderCloud
   sellerName: string
-
-  //  buyer url and client ID are needed for impersonating buyers
-  buyerConfigs: any
 
   /**
    * An array of fields on a product that should be monitored for changes.

--- a/src/UI/Seller/src/assets/appConfigs/README.md
+++ b/src/UI/Seller/src/assets/appConfigs/README.md
@@ -12,5 +12,4 @@ You can have any number of configurations each representing a deployment. By def
 | translateBlobUrl              | The base url to the folder including your translations. See https://github.com/ngx-translate/core for more info                                  |
 | blobStorageUrl                | the base url to the blob storage account                                                                                                         |
 | orderCloudApiUrl              | The base url to the OrderCloud API. Can be one of: https://api.ordercloud.io, https://sandboxapi.ordercloud.io, https://stagingapi.ordercloud.io       |
-| buyerConfigs                  | A dictionary where each key represents a new buyer and details about that buyer such as clientID and buyerURl used for impersonation             |
 | superProductFieldsToMonitor   | Fields to monitor for changes. Until approved by seller product will not be purchasable                                                          |

--- a/src/UI/Seller/src/assets/appConfigs/README.md
+++ b/src/UI/Seller/src/assets/appConfigs/README.md
@@ -11,5 +11,4 @@ You can have any number of configurations each representing a deployment. By def
 | cmsUrl                        | The base url to the hosted CMS URL by OrderCloud (non-official)                                                                                  |
 | translateBlobUrl              | The base url to the folder including your translations. See https://github.com/ngx-translate/core for more info                                  |
 | blobStorageUrl                | the base url to the blob storage account                                                                                                         |
-| orderCloudApiUrl              | The base url to the OrderCloud API. Can be one of: https://api.ordercloud.io, https://sandboxapi.ordercloud.io, https://stagingapi.ordercloud.io       |
-| superProductFieldsToMonitor   | Fields to monitor for changes. Until approved by seller product will not be purchasable                                                          |
+| orderCloudApiUrl              | The base url to the OrderCloud API. Can be one of: https://api.ordercloud.io, https://sandboxapi.ordercloud.io, https://stagingapi.ordercloud.io       |                                                     |

--- a/src/UI/Seller/src/assets/appConfigs/defaultadmin-production.json
+++ b/src/UI/Seller/src/assets/appConfigs/defaultadmin-production.json
@@ -8,6 +8,5 @@
   "cmsUrl": "https://ordercloud-cms.azurewebsites.net",
   "translateBlobUrl": "https://my-translation-files/ngx-translate/i18n/",
   "blobStorageUrl": "https://myblobstoragecontainer.blob.core.windows.net",
-  "orderCloudApiUrl": "https://api.ordercloud.io",
-  "superProductFieldsToMonitor": []
+  "orderCloudApiUrl": "https://api.ordercloud.io"
 }

--- a/src/UI/Seller/src/assets/appConfigs/defaultadmin-production.json
+++ b/src/UI/Seller/src/assets/appConfigs/defaultadmin-production.json
@@ -9,11 +9,5 @@
   "translateBlobUrl": "https://my-translation-files/ngx-translate/i18n/",
   "blobStorageUrl": "https://myblobstoragecontainer.blob.core.windows.net",
   "orderCloudApiUrl": "https://api.ordercloud.io",
-  "buyerConfigs": {
-    "Default Buyer": {
-      "clientID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-      "buyerUrl": "https://my-default-buyer-test.com/"
-    }
-  },
   "superProductFieldsToMonitor": []
 }

--- a/src/UI/Seller/src/assets/appConfigs/defaultadmin-staging.json
+++ b/src/UI/Seller/src/assets/appConfigs/defaultadmin-staging.json
@@ -8,6 +8,5 @@
   "cmsUrl": "https://ordercloud-cms-staging.azurewebsites.net",
   "translateBlobUrl": "https://my-translation-files/ngx-translate/i18n/",
   "blobStorageUrl": "https://myblobstoragecontainer.blob.core.windows.net",
-  "orderCloudApiUrl": "https://stagingapi.ordercloud.io",
-  "superProductFieldsToMonitor": []
+  "orderCloudApiUrl": "https://stagingapi.ordercloud.io"
 }

--- a/src/UI/Seller/src/assets/appConfigs/defaultadmin-staging.json
+++ b/src/UI/Seller/src/assets/appConfigs/defaultadmin-staging.json
@@ -9,11 +9,5 @@
   "translateBlobUrl": "https://my-translation-files/ngx-translate/i18n/",
   "blobStorageUrl": "https://myblobstoragecontainer.blob.core.windows.net",
   "orderCloudApiUrl": "https://stagingapi.ordercloud.io",
-  "buyerConfigs": {
-    "Default Buyer": {
-      "clientID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-      "buyerUrl": "https://my-default-buyer-test.com/"
-    }
-  },
   "superProductFieldsToMonitor": []
 }

--- a/src/UI/Seller/src/assets/appConfigs/defaultadmin-test.json
+++ b/src/UI/Seller/src/assets/appConfigs/defaultadmin-test.json
@@ -8,6 +8,5 @@
   "cmsUrl": "https://ordercloud-cms-test.azurewebsites.net",
   "translateBlobUrl": "https://my-translation-files/ngx-translate/i18n/",
   "blobStorageUrl": "https://myblobstoragecontainer.blob.core.windows.net",
-  "orderCloudApiUrl": "https://sandboxapi.ordercloud.io",
-  "superProductFieldsToMonitor": []
+  "orderCloudApiUrl": "https://sandboxapi.ordercloud.io"
 }

--- a/src/UI/Seller/src/assets/appConfigs/defaultadmin-test.json
+++ b/src/UI/Seller/src/assets/appConfigs/defaultadmin-test.json
@@ -9,11 +9,5 @@
   "translateBlobUrl": "https://my-translation-files/ngx-translate/i18n/",
   "blobStorageUrl": "https://myblobstoragecontainer.blob.core.windows.net",
   "orderCloudApiUrl": "https://sandboxapi.ordercloud.io",
-  "buyerConfigs": {
-    "Default Buyer": {
-      "clientID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-      "buyerUrl": "https://my-default-buyer-test.com/"
-    }
-  },
   "superProductFieldsToMonitor": []
 }


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
We are not using the BuyerConfigs properties from the environment files in the admin app. This PR removes them completely.

For Reference: [HDS-363](https://four51.atlassian.net/browse/HDS-363) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
