### PR TITLE
HDS-307 fix error on referencing images when null

### DIFF
--- a/src/UI/Buyer/src/app/components/products/spec-form/spec-form.service.ts
+++ b/src/UI/Buyer/src/app/components/products/spec-form/spec-form.service.ts
@@ -70,6 +70,9 @@ export class SpecFormService {
     specs: Spec[],
     specForm?: FormGroup
   ): string {
+    if(!images || images === null) {
+      images = []
+    }
     if (!specs.length) {
       const firstImage = images[0]
       return firstImage?.Url


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Fix an error that occurs when the product.xp.Images = null

For Reference: [HDS-364](https://four51.atlassian.net/browse/HDS-364) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
