### PR TITLE
HDS-379: Prevent UseCumulativeQty if no variants or specs

### DIFF
--- a/src/UI/Seller/src/app/products/components/price-break-editor/price-break-editor.component.html
+++ b/src/UI/Seller/src/app/products/components/price-break-editor/price-break-editor.component.html
@@ -119,6 +119,15 @@
         <label for="UseCumulativeQuantity" translate
           >ADMIN.PRODUCT_EDIT.PRICE_BREAK_APPLICATION</label
         >
+        <div
+          *ngIf="_specCount === 0 && _variantCount === 0"
+          class="d-flex align-items-center mb-2"
+        >
+          <fa-icon [icon]="faExclamationCircle"></fa-icon
+          ><small class="ml-2" translate=""
+            >ADMIN.PRODUCT_EDIT.APPLY_INFO_TEXT</small
+          >
+        </div>
         <select
           [attr.disabled]="readonly ? true : null"
           type="dropdown"
@@ -130,6 +139,7 @@
           <option
             [selected]="priceScheduleEditable.UseCumulativeQuantity == true"
             [value]="true"
+            [disabled]="_specCount === 0 && _variantCount === 0"
             translate
           >
             ADMIN.PRODUCT_EDIT.APPLY_ACROSS_VARIATIONS

--- a/src/UI/Seller/src/app/products/components/price-break-editor/price-break-editor.component.ts
+++ b/src/UI/Seller/src/app/products/components/price-break-editor/price-break-editor.component.ts
@@ -5,7 +5,11 @@ import {
   OcBuyerService,
 } from '@ordercloud/angular-sdk'
 import { ToastrService } from 'ngx-toastr'
-import { faCog, faTrash } from '@fortawesome/free-solid-svg-icons'
+import {
+  faCog,
+  faExclamationCircle,
+  faTrash,
+} from '@fortawesome/free-solid-svg-icons'
 import { BuyerTempService } from '@app-seller/shared/services/middleware-api/buyer-temp.service'
 import { SupportedRates } from '@app-seller/models/currency-geography.types'
 
@@ -28,6 +32,15 @@ export class PriceBreakEditor {
       this.newPriceBreak = this.getEmptyBreak()
     }
   }
+  @Input()
+  set variantCount(n: number) {
+    this._variantCount = n
+  }
+
+  @Input()
+  set specCount(n: number) {
+    this._specCount = n
+  }
 
   @Output()
   priceScheduleUpdated = new EventEmitter<PriceSchedule>()
@@ -35,6 +48,9 @@ export class PriceBreakEditor {
 
   faCog = faCog
   faTrash = faTrash
+  faExclamationCircle = faExclamationCircle
+  _specCount: number
+  _variantCount: number
 
   isAddingPriceBreak = false
   newPriceBreak

--- a/src/UI/Seller/src/app/products/components/product-pricing/product-pricing.component.html
+++ b/src/UI/Seller/src/app/products/components/product-pricing/product-pricing.component.html
@@ -25,6 +25,8 @@
     [readonly]="readonly"
     [currency]="supplierCurrency"
     [priceSchedule]="supplierPriceSchedule"
+    [variantCount]="superProduct?.Variants?.length"
+    [specCount]="superProduct?.Specs?.length"
     (priceScheduleUpdated)="updateSupplierPriceSchedule($event)"
   >
   </price-break-editor>
@@ -114,6 +116,8 @@
           [readonly]="true"
           [currency]="sellerCurrency"
           [priceSchedule]="buyerMarkedUpSupplierPrices"
+          [variantCount]="superProduct?.Variants?.length"
+          [specCount]="superProduct?.Specs?.length"
         >
         </price-break-editor>
       </ng-container>
@@ -124,6 +128,8 @@
           [currency]="sellerCurrency"
           [priceSchedule]="overridePriceScheduleEditable"
           (priceScheduleUpdated)="updateOverridePriceSchedule($event)"
+          [variantCount]="superProduct?.Variants?.length"
+          [specCount]="superProduct?.Specs?.length"
         >
         </price-break-editor>
       </ng-container>


### PR DESCRIPTION
## Description
- Prevent users from choosing to assign UseCumulativeQuantity (Apply Price Breaks Across Variations) if there are no specs or variants on the product.

For Reference: [HDS-379](https://four51.atlassian.net/browse/HDS-379) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
