### PR TITLE
HDS-266 fix reorder for anon users

### DIFF
--- a/src/UI/Buyer/src/app/services/order/cart.service.ts
+++ b/src/UI/Buyer/src/app/services/order/cart.service.ts
@@ -105,15 +105,19 @@ export class CartService {
       return await this.upsertLineItem(lineItem)
     }
     if (!this.initializingOrder) {
-      this.initializingOrder = true
-      if(this.userService.isAnonymous()) {
-        await this.state.createAndSetOrder(this.order)
-      } else {
-        await this.state.reset()
-      }
-      this.initializingOrder = false
+      await this.initializeOrder()
       return await this.upsertLineItem(lineItem)
     }
+  }
+
+  async initializeOrder(): Promise<void> {
+    this.initializingOrder = true
+    if(this.userService.isAnonymous()) {
+      await this.state.createAndSetOrder(this.order)
+    } else {
+      await this.state.reset()
+    }
+    this.initializingOrder = false
   }
 
   async remove(lineItemID: string): Promise<void> {
@@ -183,6 +187,9 @@ export class CartService {
   async addMany(
     lineItem: HSLineItem[]
   ): Promise<HSLineItem[]> {
+    if(_isUndefined(this.order.DateCreated)) {
+      await this.initializeOrder()
+    }
     const req = lineItem.map((li) => this.add(li))
     return Promise.all(req)
   }


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Reorder was only adding the first line item to cart when there were more than one valid line items. Need to reinitialize the order before calling the add() function.

For Reference: [HDS-266](https://four51.atlassian.net/browse/HDS-266) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
