### PR TITLE
HDS 316 update order summary meta

### DIFF
--- a/src/UI/Buyer/src/app/components/checkout/checkout/checkout.component.ts
+++ b/src/UI/Buyer/src/app/components/checkout/checkout/checkout.component.ts
@@ -110,15 +110,8 @@ export class OCMCheckout implements OnInit {
     this.isAnon = this.context.currentUser.isAnonymous()
     this.currentPanel = this.isAnon ? 'login' : 'shippingAddressLoading'
     this.initLoadingIndicator();
-    this.orderSummaryMeta = getOrderSummaryMeta(
-      this.order,
-      this.orderPromotions,
-      this.lineItems.Items,
-      this.shipEstimates,
-      this.currentPanel
-    )
+    this.updateOrderMeta()
     this.setValidation('login', !this.isAnon)
-
     this.isNewCard = false
     this.invalidLineItems = await this.context.order.cart.getInvalidLineItems()
     if (this.invalidLineItems?.length) {
@@ -357,8 +350,9 @@ export class OCMCheckout implements OnInit {
     }
   }
 
-  handleCheckoutError(): void {
+  async handleCheckoutError(): Promise<void> {
     this.orderErrorModal = ModalState.Closed
+    await this.refreshOrderUpdateMeta()
     if (this.checkoutError.ErrorCode === ErrorCodes.MissingShippingSelections.code) {
       this.currentPanel = 'shippingAddress'
     } else if (this.checkoutError.ErrorCode === ErrorCodes.AlreadySubmitted.code) {
@@ -396,13 +390,7 @@ export class OCMCheckout implements OnInit {
 
   toSection(id: string): void {
     this.orderPromotions = this.context.order.promos.get()?.Items
-    this.orderSummaryMeta = getOrderSummaryMeta(
-      this.order,
-      this.orderPromotions,
-      this.lineItems.Items,
-      this.shipEstimates,
-      id
-    )
+    this.updateOrderMeta(id)
     const prevIdx = Math.max(this.sections.findIndex((x) => x.id === id) - 1, 0)
 
     // set validation to true on all previous sections
@@ -431,15 +419,20 @@ export class OCMCheckout implements OnInit {
     this.currentPanel = $event.panelId
   }
 
-  updateOrderMeta(promos?: CustomEvent<OrderPromotion[]>): void {
-    this.orderPromotions = this.context.order.promos.get().Items
-    this.orderPromotions = promos.detail
+  async refreshOrderUpdateMeta(): Promise<void> {
+    await this.context.order.reset()
+    this.lineItems = this.context.order.cart.get()
+    this.orderPromotions = this.context.order.promos.get()?.Items
+    this.updateOrderMeta()
+  }
+
+  updateOrderMeta(panelID?: string): void {
     this.orderSummaryMeta = getOrderSummaryMeta(
       this.order,
       this.orderPromotions,
       this.lineItems.Items,
       this.shipEstimates,
-      this.currentPanel
+      panelID || this.currentPanel
     )
   }
 

--- a/src/UI/Buyer/src/app/services/order/cart.service.ts
+++ b/src/UI/Buyer/src/app/services/order/cart.service.ts
@@ -105,15 +105,19 @@ export class CartService {
       return await this.upsertLineItem(lineItem)
     }
     if (!this.initializingOrder) {
-      this.initializingOrder = true
-      if(this.userService.isAnonymous()) {
-        await this.state.createAndSetOrder(this.order)
-      } else {
-        await this.state.reset()
-      }
-      this.initializingOrder = false
+      await this.initializeOrder()
       return await this.upsertLineItem(lineItem)
     }
+  }
+
+  async initializeOrder(): Promise<void> {
+    this.initializingOrder = true
+    if(this.userService.isAnonymous()) {
+      await this.state.createAndSetOrder(this.order)
+    } else {
+      await this.state.reset()
+    }
+    this.initializingOrder = false
   }
 
   async remove(lineItemID: string): Promise<void> {
@@ -183,6 +187,9 @@ export class CartService {
   async addMany(
     lineItem: HSLineItem[]
   ): Promise<HSLineItem[]> {
+    if(_isUndefined(this.order.DateCreated)) {
+      await this.initializeOrder()
+    }
     const req = lineItem.map((li) => this.add(li))
     return Promise.all(req)
   }

--- a/src/UI/Buyer/src/app/services/order/cart.service.ts
+++ b/src/UI/Buyer/src/app/services/order/cart.service.ts
@@ -111,13 +111,17 @@ export class CartService {
   }
 
   async initializeOrder(): Promise<void> {
-    this.initializingOrder = true
-    if(this.userService.isAnonymous()) {
-      await this.state.createAndSetOrder(this.order)
-    } else {
-      await this.state.reset()
+    try {
+      this.initializingOrder = true
+      if (this.userService.isAnonymous()) {
+        await this.state.createAndSetOrder(this.order)
+      } else {
+        await this.state.reset()
+      }
+    } finally {
+      this.initializingOrder = false
     }
-    this.initializingOrder = false
+
   }
 
   async remove(lineItemID: string): Promise<void> {
@@ -187,7 +191,7 @@ export class CartService {
   async addMany(
     lineItem: HSLineItem[]
   ): Promise<HSLineItem[]> {
-    if(_isUndefined(this.order.DateCreated)) {
+    if (_isUndefined(this.order.DateCreated)) {
       await this.initializeOrder()
     }
     const req = lineItem.map((li) => this.add(li))

--- a/src/UI/Buyer/src/app/services/purchase-order.helper.ts
+++ b/src/UI/Buyer/src/app/services/purchase-order.helper.ts
@@ -65,7 +65,7 @@ export const getOrderSummaryMeta = (
   const shouldHideShippingAndText = !!ShippingAndTaxOverrideText;
 
   const CreditCardDisplaySubtotal = StandardLineItems.reduce((accumulator, li) => (li.Quantity * li.UnitPrice) + accumulator, 0);
-  const DiscountTotal = orderPromos.reduce((accumulator, promo) => (promo.Amount) + accumulator, 0);
+  const DiscountTotal = orderPromos?.reduce((accumulator, promo) => (promo.Amount) + accumulator, 0);
 
   const POSubtotal = POLineItems.reduce((accumulator, li) => (li.Quantity * li.UnitPrice) + accumulator, 0);
 


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
When there is a checkout error we need to make sure the order summary component is updated with fresh order/line item data.

For Reference: [HDS-316](https://four51.atlassian.net/browse/HDS-316) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
