### PR TITLE
Allow registered users to view products

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
@@ -1,4 +1,4 @@
-﻿using Headstart.Models;
+using Headstart.Models;
 using Headstart.Models.Misc;
 using OrderCloud.SDK;
 using System.Linq;
@@ -205,7 +205,7 @@ namespace Headstart.API.Commands
         {
             var userGroupAssignments = await _oc.UserGroups.ListAllUserAssignmentsAsync(buyerID, userID: newUserID);
             await Throttler.RunAsync(userGroupAssignments, 100, 5, assignment =>
-                RemoveAndAddUserGroupAssignment(buyerID, newUserID, assignment.UserGroupID)
+                RemoveAndAddUserGroupAssignment(buyerID, newUserID, assignment?.UserGroupID)
                 ); 
         }
 

--- a/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
@@ -26,12 +26,10 @@ namespace Headstart.API.Commands
     {
         private IOrderCloudClient _oc;
         private readonly AppSettings _settings;
-        private readonly IHSCatalogCommand _catalogCommand;
-        public HSBuyerLocationCommand(AppSettings settings, IOrderCloudClient oc, IHSCatalogCommand catalogCommand)
+        public HSBuyerLocationCommand(AppSettings settings, IOrderCloudClient oc)
         {
             _settings = settings;
             _oc = oc;
-            _catalogCommand = catalogCommand;
         }
 
         public async Task<HSBuyerLocation> Get(string buyerID, string buyerLocationID)
@@ -211,6 +209,7 @@ namespace Headstart.API.Commands
 
         // Temporary work around for a platform issue. When a new user is registered we need to 
         // delete and reassign usergroup assignments for that user to view products
+        // issue: https://four51.atlassian.net/browse/EX-2222
         private async Task RemoveAndAddUserGroupAssignment(string buyerID, string newUserID, string userGroupID)
         {
             await _oc.UserGroups.DeleteUserAssignmentAsync(buyerID, userGroupID, newUserID);

--- a/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
@@ -19,7 +19,7 @@ namespace Headstart.API.Commands
         Task<HSBuyerLocation> Save(string buyerID, string buyerLocationID, HSBuyerLocation buyerLocation, string token, IOrderCloudClient oc = null);
         Task Delete(string buyerID, string buyerLocationID);
         Task CreateSinglePermissionGroup(string buyerLocationID, string permissionGroupID);
-        Task AssignNewUserAnonUserGroups(string buyerID, string newUserID);
+        Task ReassignUserGroups(string buyerID, string newUserID);
     }
 
     public class HSBuyerLocationCommand : IHSBuyerLocationCommand
@@ -199,7 +199,7 @@ namespace Headstart.API.Commands
             }
         }
 
-        public async Task AssignNewUserAnonUserGroups(string buyerID, string newUserID)
+        public async Task ReassignUserGroups(string buyerID, string newUserID)
         {
             var userGroupAssignments = await _oc.UserGroups.ListAllUserAssignmentsAsync(buyerID, userID: newUserID);
             await Throttler.RunAsync(userGroupAssignments, 100, 5, assignment =>

--- a/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
@@ -136,7 +136,7 @@ namespace Headstart.Common.Controllers
         [HttpPut, Route("{buyerID}/transferanonymous/{newUserID}")]
         public async Task ApplyAnonUserGroupsToNewUser(string buyerID, string newUserID)
         {
-            await _buyerLocationCommand.AssignNewUserAnonUserGroups(buyerID, newUserID, UserContext);
+            await _buyerLocationCommand.AssignNewUserAnonUserGroups(buyerID, newUserID);
         }
     }
 }

--- a/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
@@ -131,5 +131,12 @@ namespace Headstart.Common.Controllers
         {
             return await _locationPermissionCommand.ListUserGroupsForNewUser(args, buyerID, homeCountry, UserContext);
         }
+
+        [DocName("PUT usergroups from anonymous to new user"), OrderCloudUserAuth(ApiRole.Shopper)]
+        [HttpPut, Route("{buyerID}/transferanonymous/{newUserID}")]
+        public async Task ApplyAnonUserGroupsToNewUser(string buyerID, string newUserID)
+        {
+            await _buyerLocationCommand.AssignNewUserAnonUserGroups(buyerID, newUserID, UserContext);
+        }
     }
 }

--- a/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
@@ -133,10 +133,10 @@ namespace Headstart.Common.Controllers
         }
 
         [DocName("PUT usergroups from anonymous to new user"), OrderCloudUserAuth(ApiRole.Shopper)]
-        [HttpPut, Route("{buyerID}/transferanonymous/{newUserID}")]
-        public async Task ApplyAnonUserGroupsToNewUser(string buyerID, string newUserID)
+        [HttpPut, Route("{buyerID}/reassignusergroups/{newUserID}")]
+        public async Task ReassignUserGroups(string buyerID, string newUserID)
         {
-            await _buyerLocationCommand.AssignNewUserAnonUserGroups(buyerID, newUserID);
+            await _buyerLocationCommand.ReassignUserGroups(buyerID, newUserID);
         }
     }
 }

--- a/src/UI/Buyer/src/app/services/auth/auth.service.ts
+++ b/src/UI/Buyer/src/app/services/auth/auth.service.ts
@@ -102,7 +102,7 @@ export class AuthService {
     // temporary workaround for platform issue
     // need to remove and reset userGroups for newly registered user to see products
     // issue: https://four51.atlassian.net/browse/EX-2222
-    await HeadStartSDK.BuyerLocations.SetUserGroups(newUser.Buyer.ID, newUser.ID)
+    await HeadStartSDK.BuyerLocations.ReassignUserGroups(newUser.Buyer.ID, newUser.ID)
     this.loginWithTokens(token.access_token)
     return token
   }

--- a/src/UI/Buyer/src/app/services/auth/auth.service.ts
+++ b/src/UI/Buyer/src/app/services/auth/auth.service.ts
@@ -22,6 +22,7 @@ import { TokenHelperService } from '../token-helper/token-helper.service'
 import { ContentManagementClient } from '@ordercloud/cms-sdk'
 import { AppConfig } from 'src/app/models/environment.types'
 import { BaseResolveService } from '../base-resolve/base-resolve.service'
+import BuyerLocations from '@ordercloud/headstart-sdk/dist/api/BuyerLocations'
 
 @Injectable({
   providedIn: 'root',
@@ -97,6 +98,8 @@ export class AuthService {
   async register(me: MeUser): Promise<AccessTokenBasic> {
     const anonToken = await this.getAnonymousToken()
     const token = await Me.Register(me, {anonUserToken: anonToken.access_token})
+    const newUser = await Me.Get({accessToken: token.access_token})
+    await HeadStartSDK.BuyerLocations.TransferAnonUserGroups(newUser.Buyer.ID, newUser.ID, anonToken.access_token)
     this.loginWithTokens(token.access_token)
     return token
   }

--- a/src/UI/Buyer/src/app/services/auth/auth.service.ts
+++ b/src/UI/Buyer/src/app/services/auth/auth.service.ts
@@ -99,7 +99,9 @@ export class AuthService {
     const anonToken = await this.getAnonymousToken()
     const token = await Me.Register(me, {anonUserToken: anonToken.access_token})
     const newUser = await Me.Get({accessToken: token.access_token})
-    await HeadStartSDK.BuyerLocations.TransferAnonUserGroups(newUser.Buyer.ID, newUser.ID, anonToken.access_token)
+    // temporary workaround for platform issue
+    // need to remove and reset userGroups for newly registered user to see products
+    await HeadStartSDK.BuyerLocations.SetUserGroups(newUser.Buyer.ID, newUser.ID)
     this.loginWithTokens(token.access_token)
     return token
   }

--- a/src/UI/Buyer/src/app/services/auth/auth.service.ts
+++ b/src/UI/Buyer/src/app/services/auth/auth.service.ts
@@ -101,6 +101,7 @@ export class AuthService {
     const newUser = await Me.Get({accessToken: token.access_token})
     // temporary workaround for platform issue
     // need to remove and reset userGroups for newly registered user to see products
+    // issue: https://four51.atlassian.net/browse/EX-2222
     await HeadStartSDK.BuyerLocations.SetUserGroups(newUser.Buyer.ID, newUser.ID)
     this.loginWithTokens(token.access_token)
     return token

--- a/src/UI/SDK/src/api/BuyerLocations.ts
+++ b/src/UI/SDK/src/api/BuyerLocations.ts
@@ -29,7 +29,7 @@ export default class BuyerLocations {
         this.ListUserGroupsForNewUser = this.ListUserGroupsForNewUser.bind(this);
         this.ListUserGroupsByCountry = this.ListUserGroupsByCountry.bind(this);
         this.ListUserUserGroupAssignments = this.ListUserUserGroupAssignments.bind(this);
-        this.TransferAnonUserGroups = this.TransferAnonUserGroups.bind(this);
+        this.SetUserGroups = this.SetUserGroups.bind(this);
     }
 
    /**
@@ -197,7 +197,7 @@ export default class BuyerLocations {
         return await httpClient.get(`/buyerlocations/${userGroupType}/${parentID}/usergroupassignments/${userID}`, { params: {  accessToken, impersonating } } );
     }
 
-    public async TransferAnonUserGroups(buyerID: string, newUserID: string, accessToken?: string): Promise<void> {
+    public async SetUserGroups(buyerID: string, newUserID: string, accessToken?: string): Promise<void> {
         const impersonating = this.impersonating;
         this.impersonating = false;
         return await httpClient.put(`/buyerlocations/${buyerID}/transferanonymous/${newUserID}`, undefined, { params: { accessToken, impersonating } } )

--- a/src/UI/SDK/src/api/BuyerLocations.ts
+++ b/src/UI/SDK/src/api/BuyerLocations.ts
@@ -29,7 +29,7 @@ export default class BuyerLocations {
         this.ListUserGroupsForNewUser = this.ListUserGroupsForNewUser.bind(this);
         this.ListUserGroupsByCountry = this.ListUserGroupsByCountry.bind(this);
         this.ListUserUserGroupAssignments = this.ListUserUserGroupAssignments.bind(this);
-        this.SetUserGroups = this.SetUserGroups.bind(this);
+        this.ReassignUserGroups = this.ReassignUserGroups.bind(this);
     }
 
    /**
@@ -197,10 +197,10 @@ export default class BuyerLocations {
         return await httpClient.get(`/buyerlocations/${userGroupType}/${parentID}/usergroupassignments/${userID}`, { params: {  accessToken, impersonating } } );
     }
 
-    public async SetUserGroups(buyerID: string, newUserID: string, accessToken?: string): Promise<void> {
+    public async ReassignUserGroups(buyerID: string, newUserID: string, accessToken?: string): Promise<void> {
         const impersonating = this.impersonating;
         this.impersonating = false;
-        return await httpClient.put(`/buyerlocations/${buyerID}/transferanonymous/${newUserID}`, undefined, { params: { accessToken, impersonating } } )
+        return await httpClient.put(`/buyerlocations/${buyerID}/reassignusergroups/${newUserID}`, undefined, { params: { accessToken, impersonating } } )
     }
 
     /**

--- a/src/UI/SDK/src/api/BuyerLocations.ts
+++ b/src/UI/SDK/src/api/BuyerLocations.ts
@@ -29,6 +29,7 @@ export default class BuyerLocations {
         this.ListUserGroupsForNewUser = this.ListUserGroupsForNewUser.bind(this);
         this.ListUserGroupsByCountry = this.ListUserGroupsByCountry.bind(this);
         this.ListUserUserGroupAssignments = this.ListUserUserGroupAssignments.bind(this);
+        this.TransferAnonUserGroups = this.TransferAnonUserGroups.bind(this);
     }
 
    /**
@@ -194,6 +195,12 @@ export default class BuyerLocations {
         const impersonating = this.impersonating;
         this.impersonating = false;
         return await httpClient.get(`/buyerlocations/${userGroupType}/${parentID}/usergroupassignments/${userID}`, { params: {  accessToken, impersonating } } );
+    }
+
+    public async TransferAnonUserGroups(buyerID: string, newUserID: string, accessToken?: string): Promise<void> {
+        const impersonating = this.impersonating;
+        this.impersonating = false;
+        return await httpClient.put(`/buyerlocations/${buyerID}/transferanonymous/${newUserID}`, undefined, { params: { accessToken, impersonating } } )
     }
 
     /**


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
There is a platform issue that is preventing newly registered users from viewing products. 
When a user registers they automatically receive the anon users user groups. However for them to view products we need to delete the usergroup assignments and re-create them. Platform team is aware of this and has the issue logged. This is a temporary workaround.

For Reference: [HDS-229](https://four51.atlassian.net/browse/HDS-229) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
