### PR TITLE
HDS-328 - Fix suggested addresses pipe and buyer group saving errors

### DIFF
--- a/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
@@ -51,7 +51,7 @@ namespace Headstart.Common.Controllers
         [HttpPut, Route("{buyerID}/{buyerLocationID}"), OrderCloudUserAuth(ApiRole.UserGroupAdmin, ApiRole.AddressAdmin)]
         public async Task<HSBuyerLocation> Save(string buyerID, string buyerLocationID, [FromBody] HSBuyerLocation buyerLocation)
         {
-            return await _buyerLocationCommand.Save(buyerID, buyerLocationID, buyerLocation, UserContext.AccessToken, _oc);
+            return await _buyerLocationCommand.Save(buyerID, buyerLocationID, buyerLocation);
         }
 
         [DocName("Delete a Buyer Location")]

--- a/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
@@ -51,7 +51,7 @@ namespace Headstart.Common.Controllers
         [HttpPut, Route("{buyerID}/{buyerLocationID}"), OrderCloudUserAuth(ApiRole.UserGroupAdmin, ApiRole.AddressAdmin)]
         public async Task<HSBuyerLocation> Save(string buyerID, string buyerLocationID, [FromBody] HSBuyerLocation buyerLocation)
         {
-            return await _buyerLocationCommand.Save(buyerID, buyerLocationID, buyerLocation, UserContext.AccessToken);
+            return await _buyerLocationCommand.Save(buyerID, buyerLocationID, buyerLocation, UserContext.AccessToken, _oc);
         }
 
         [DocName("Delete a Buyer Location")]

--- a/src/UI/Seller/src/app/buyers/components/locations/buyer-location-edit/buyer-location-edit.component.ts
+++ b/src/UI/Seller/src/app/buyers/components/locations/buyer-location-edit/buyer-location-edit.component.ts
@@ -114,7 +114,10 @@ export class BuyerLocationEditComponent implements OnInit {
       BillingNumber: new FormControl(
         (buyerLocation.Address.xp as any).BillingNumber
       ),
-      CatalogAssignments: new FormControl(undefined, this.isCreatingNew ? [Validators.required] : undefined)
+      CatalogAssignments: new FormControl(
+        undefined,
+        this.isCreatingNew ? [Validators.required] : undefined
+      ),
     })
   }
 
@@ -174,7 +177,7 @@ export class BuyerLocationEditComponent implements OnInit {
       )
       this.dataIsSaving = false
     } catch (ex) {
-      this.suggestedAddresses = getSuggestedAddresses(ex.response.data)
+      this.suggestedAddresses = getSuggestedAddresses(ex?.response?.data)
       this.dataIsSaving = false
     }
   }
@@ -182,10 +185,10 @@ export class BuyerLocationEditComponent implements OnInit {
   async updateBuyerLocation(): Promise<void> {
     try {
       this.dataIsSaving = true
-      this.buyerLocationEditable.UserGroup
-        .xp.Country = this.buyerLocationEditable.Address.Country
+      this.buyerLocationEditable.UserGroup.xp.Country = this.buyerLocationEditable.Address.Country
       var assignments = this.resourceForm.controls['CatalogAssignments']?.value
-      this.buyerLocationEditable.UserGroup.xp.CatalogAssignments = assignments?.CatalogIDs
+      this.buyerLocationEditable.UserGroup.xp.CatalogAssignments =
+        assignments?.CatalogIDs
       const updatedBuyerLocation = await HeadStartSDK.BuyerLocations.Save(
         this.buyerID,
         this.buyerLocationEditable.Address.ID,
@@ -255,7 +258,7 @@ export class BuyerLocationEditComponent implements OnInit {
   }
 
   addCatalogAssignments(event): void {
-    this.resourceForm.controls['CatalogAssignments']?.setValue(event);
+    this.resourceForm.controls['CatalogAssignments']?.setValue(event)
   }
 
   private async handleSelectedAddressChange(address: Address): Promise<void> {

--- a/src/UI/Seller/src/app/shared/services/address-suggestion.helper.ts
+++ b/src/UI/Seller/src/app/shared/services/address-suggestion.helper.ts
@@ -1,10 +1,9 @@
-import { BuyerAddress } from '@ordercloud/angular-sdk'
-
-export const getSuggestedAddresses = (ex): Array<BuyerAddress> => {
-  for (const err of ex) {
-    if (err.ErrorCode === 'blocked by web hook') {
-      return err.Data?.Body?.SuggestedAddresses
-    }
+import { BuyerAddress } from 'ordercloud-javascript-sdk'
+export const getSuggestedAddresses = (ex): BuyerAddress[] => {
+  const suggestions = ex?.response?.data?.Data?.SuggestedAddresses
+  if (suggestions && Array.isArray(suggestions) && suggestions !== []) {
+    return suggestions
   }
+  // TODO - if suggestions === []
   throw ex
 }


### PR DESCRIPTION
Suggested addresses pipe was trying to iterate over errors which didn't exist, hence "n is not iteratable" error.

Buyer groups weren't saving due to a null ocClient. passing the client from the controller to the command now.
## Description

For Reference: [HDS-328](https://four51.atlassian.net/browse/HDS-328) <!--  Ignore if PR from external developer -->

- [x ] I have updated the acceptance criteria on the task so that it can be tested
