### PR TITLE
HDS-354 - updates to seeding process to include initial storefront and so its more friendly to updates

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/BuyerCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/BuyerCommand.cs
@@ -102,7 +102,7 @@ namespace Headstart.API.Commands
             var token = oc == null ? null : accessToken;
             var ocClient = oc ?? _oc;
 
-            buyer.ID = "{buyerIncrementor}";
+            buyer.ID = buyer.ID ?? "{buyerIncrementor}";
             buyer.Active = true;
             var ocBuyer = await ocClient.Buyers.CreateAsync(buyer, accessToken);
             buyer.ID = ocBuyer.ID;

--- a/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/BuyerLocationCommand.cs
@@ -109,12 +109,12 @@ namespace Headstart.API.Commands
             {
                 existingLocation = await ocClient.UserGroups.GetAsync(buyerID, buyerLocationID, token);
             } catch (Exception e) { } // Do nothing if not found
-            var updatedBuyerAddress = ocClient.Addresses.SaveAsync<HSAddressBuyer>(buyerID, buyerLocationID, buyerLocation.Address, accessToken: token);
-            var updatedBuyerUserGroup = ocClient.UserGroups.SaveAsync<HSLocationUserGroup>(buyerID, buyerLocationID, buyerLocation.UserGroup, accessToken: token);
+            var updatedBuyerAddress = await ocClient.Addresses.SaveAsync<HSAddressBuyer>(buyerID, buyerLocationID, buyerLocation.Address, accessToken: token);
+            var updatedBuyerUserGroup = await ocClient.UserGroups.SaveAsync<HSLocationUserGroup>(buyerID, buyerLocationID, buyerLocation.UserGroup, accessToken: token);
             var location = new HSBuyerLocation
             {
-                Address = await updatedBuyerAddress,
-                UserGroup = await updatedBuyerUserGroup,
+                Address = updatedBuyerAddress,
+                UserGroup = updatedBuyerUserGroup,
             };
             if (existingLocation == null)
 			{

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Headstart.Common.Helpers;
 using Headstart.Models;
@@ -11,13 +11,14 @@ namespace Headstart.API.Commands
 {
     public class SeedConstants
     {
-        public static string BuyerApiClientName = "Default HeadStart Buyer UI";
+        public static string BuyerApiClientName = "Storefront - Default Buyer";
         public static string BuyerLocalApiClientName = "Default HeadStart Buyer UI LOCAL"; // used for pointing integration events to the ngrok url
         public static string SellerApiClientName = "Default HeadStart Admin UI";
         public static string IntegrationsApiClientName = "Middleware Integrations";
         public static string SellerUserName = "Default_Admin";
         public static string FullAccessSecurityProfile = "DefaultContext";
-        public static string DefaultBuyerName = "Default HeadStart Buyer";
+        public static string DefaultBuyerName = "Default Headstart Buyer";
+        public static string DefaultBuyerID = "0001";
         public static string DefaultLocationID = "default-buyerLocation";
         public static string AllowedSecretChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
@@ -39,7 +40,7 @@ namespace Headstart.API.Commands
             };
         }
 
-        public static User MIddlewareIntegrationsUser()
+        public static User MiddlewareIntegrationsUser()
         {
             return new User()
             {
@@ -56,6 +57,7 @@ namespace Headstart.API.Commands
         {
             return new HSBuyer
             {
+                ID = DefaultBuyerID,
                 Name = DefaultBuyerName,
                 Active = true,
                 xp = new BuyerXp
@@ -122,7 +124,7 @@ namespace Headstart.API.Commands
             };
         }
 
-        public static ApiClient BuyerClient()
+        public static ApiClient BuyerClient(EnvironmentSeed seed)
         {
             return new ApiClient()
             {
@@ -133,12 +135,12 @@ namespace Headstart.API.Commands
                 AllowSeller = false,
                 AccessTokenDuration = 600,
                 RefreshTokenDuration = 43200,
-                DefaultContextUserName = AnonymousBuyerUser().ID,
-                IsAnonBuyer = true
+                DefaultContextUserName = seed.EnableAnonymousShopping ? AnonymousBuyerUser().ID : null,
+                IsAnonBuyer = seed.EnableAnonymousShopping
             };
         }
 
-        public static ApiClient BuyerLocalClient()
+        public static ApiClient BuyerLocalClient(EnvironmentSeed seed)
         {
             return new ApiClient()
             {
@@ -149,8 +151,8 @@ namespace Headstart.API.Commands
                 AllowSeller = false,
                 AccessTokenDuration = 600,
                 RefreshTokenDuration = 43200,
-                DefaultContextUserName = AnonymousBuyerUser().ID,
-                IsAnonBuyer = true
+                DefaultContextUserName = seed.EnableAnonymousShopping ? AnonymousBuyerUser().ID : null,
+                IsAnonBuyer = seed.EnableAnonymousShopping
             };
         }
         #endregion

--- a/src/Middleware/src/Headstart.API/Startup.cs
+++ b/src/Middleware/src/Headstart.API/Startup.cs
@@ -80,11 +80,6 @@ namespace Headstart.API
                 ConnectionString = _settings.BlobSettings.ConnectionString,
                 Container = _settings.BlobSettings.ContainerNameExchangeRates
             };
-            var middlewareErrorsConfig = new BlobServiceConfig()
-            {
-                ConnectionString = _settings.BlobSettings.ConnectionString,
-                Container = "unhandled-errors-log"
-            };
             var assetConfig = new BlobServiceConfig()
             {
                 ConnectionString = _settings.BlobSettings.ConnectionString,

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using ordercloud.integrations.library;
 using Newtonsoft.Json;
@@ -75,6 +75,13 @@ namespace Headstart.Models.Misc
 		/// An optional array of buyers to create as part of the initial seeding
 		/// </summary>
 		public List<HSBuyer> Buyers { get; set; } = new List<HSBuyer> { };
+
+		/// <summary>
+		/// Defaults to true
+		/// Enables anonymous shopping whereby users do not have to be logged in to view products or submit an order
+		/// pricing and visibility will be determined by what the default user can see
+		/// </summary>
+		public bool EnableAnonymousShopping { get; set; } = true;
 
 		/// <summary>
 		/// An optional string to specify a buyer which the anonymous buyer user will be assigned to


### PR DESCRIPTION
## Description
- Initially seeding an organization will create a storefront (API Client with AppName starting with "Storefront - "
- On certain resources only create once so that seeding process can be safely called after initial seeding for updates
- Add new property"seed.EnableAnonymousShopping" that lets you define whether or not you application should be anon-shopping enabled. Updates will apply correct logic to remove or add anonymous shopping

For Reference: [HDS-354](https://four51.atlassian.net/browse/HDS-354)

- [x] I have updated the acceptance criteria on the task so that it can be tested
