### PR TITLE
HDS-376 - Add Toastr to disabled variants button

### DIFF
--- a/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.html
+++ b/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.html
@@ -1108,17 +1108,26 @@
       </li>
       <!-- /Filters -->
       <!-- Varitaions -->
-      <li
-        [ngbNavItem]="5"
-        [disabled]="!_superHSProductEditable?.Product?.ID"
-        id="5"
-      >
-        <a [fragment]="variants" class="text-muted" ngbNavLink translate
-          >ADMIN.PRODUCT_EDIT.VARIANTS
+      <li *ngIf="!_superHSProductEditable?.Product?.ID" [ngbNavItem]="5" id="5">
+        <a
+          [fragment]="variants"
+          class="text-muted nav-link"
+          (click)="showVariantToastr()"
+          translate
+        >
+          ADMIN.PRODUCT_EDIT.VARIANTS
           <span class="badge badge-pill badge-info">{{
             _superHSProductEditable?.Variants?.length || 0
-          }}</span></a
-        >
+          }}</span>
+        </a>
+      </li>
+      <li *ngIf="_superHSProductEditable?.Product?.ID" [ngbNavItem]="5" id="5">
+        <a [fragment]="variants" class="text-muted" ngbNavLink translate>
+          ADMIN.PRODUCT_EDIT.VARIANTS
+          <span class="badge badge-pill badge-info">{{
+            _superHSProductEditable?.Variants?.length || 0
+          }}</span>
+        </a>
         <ng-template ngbNavContent>
           <product-variations-component
             [readonly]="readonly"

--- a/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.ts
+++ b/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.ts
@@ -67,6 +67,7 @@ import { UserContext } from '@app-seller/models/user.types'
 import { AppConfig } from '@app-seller/models/environment.types'
 import { AssetService } from '@app-seller/shared/services/assets/asset.service'
 import { getProductMediumImageUrl } from '@app-seller/shared/services/assets/asset.helper'
+import { TranslateService } from '@ngx-translate/core'
 
 @Component({
   selector: 'app-product-edit',
@@ -154,7 +155,8 @@ export class ProductEditComponent implements OnInit, OnDestroy {
     private appAuthService: AppAuthService,
     @Inject(applicationConfiguration) private appConfig: AppConfig,
     private toastrService: ToastrService,
-    private assetService: AssetService
+    private assetService: AssetService,
+    private translate: TranslateService
   ) {}
 
   async ngOnInit(): Promise<void> {
@@ -599,6 +601,13 @@ export class ProductEditComponent implements OnInit, OnDestroy {
     }
   }
 
+  showVariantToastr(): void {
+    this.toastrService.warning(
+      this.translate.instant('ADMIN.PRODUCT_EDIT.VARIANTS_WARNING'),
+      'Warning',
+      { onActivateTick: true }
+    )
+  }
   productWasModified(): boolean {
     return (
       JSON.stringify(this._superHSProductEditable) !==


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description - Add Toastr to variant button. When attempting to edit variants before a SKU is set, a toastr will appear telling you to set a sku first.

For Reference: [HDS-376](https://four51.atlassian.net/browse/HDS-376) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
