### PR TITLE
HDS-396 disable approver permission when no order approvals

### DIFF
--- a/src/UI/Seller/src/app/buyers/buyers.module.ts
+++ b/src/UI/Seller/src/app/buyers/buyers.module.ts
@@ -14,9 +14,14 @@ import { BuyerEditComponent } from './components/buyers/buyer-edit/buyer-edit.co
 import { BuyerLocationPermissions } from './components/locations/buyer-location-permissions/buyer-location-permissions'
 import { BuyerCatalogTableComponent } from './components/catalogs/buyer-catalog-table/buyer-catalog-table.component'
 import { BuyerLocationCatalogs } from './components/locations/buyer-location-catalogs/buyer-location-catalogs.component'
+import { NgbModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap'
 
 @NgModule({
-  imports: [SharedModule, BuyersRoutingModule, PerfectScrollbarModule],
+  imports: [SharedModule, 
+    BuyersRoutingModule, 
+    PerfectScrollbarModule,
+    NgbModule,
+    NgbTooltipModule],
   declarations: [
     BuyerTableComponent,
     BuyerEditComponent,

--- a/src/UI/Seller/src/app/buyers/components/locations/buyer-location-permissions/buyer-location-permissions.component.html
+++ b/src/UI/Seller/src/app/buyers/components/locations/buyer-location-permissions/buyer-location-permissions.component.html
@@ -22,8 +22,11 @@
               {{ user.Username }}
             </td>
             <td *ngFor="let permissionType of permissionTypes" class="">
-              <label class="switch mb-0">
+              <label class="switch mb-0" 
+                [ngbTooltip]="isPermissionDisabled(permissionType.UserGroupSuffix, user.ID) ? locationApprovalsTooltip : '' " 
+                container="body">
                 <input
+                  [disabled]="isPermissionDisabled(permissionType.UserGroupSuffix, user.ID)"
                   class="form-check-input"
                   type="checkbox"
                   (click)="


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
1. Prevents admin users from assigning order approver permissions if there are no approval rules for that location
2. Displays tooltip explaining why the toggle is disabled.

For Reference: [HDS-396](https://four51.atlassian.net/browse/HDS-396) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
