### PR TITLE
HDS-395 cannot patch order before submitted

### DIFF
--- a/src/UI/Buyer/src/app/components/checkout/checkout/checkout.component.ts
+++ b/src/UI/Buyer/src/app/components/checkout/checkout/checkout.component.ts
@@ -8,6 +8,7 @@ import {
   Payment,
   BuyerCreditCard,
   OrderPromotion,
+  Orders,
 } from 'ordercloud-javascript-sdk'
 import {
   HSOrder,
@@ -250,8 +251,6 @@ export class OCMCheckout implements OnInit {
       void this.router.navigate(['/cart'])
     } else {
       this.initLoadingIndicator('submitLoading')
-      await this.checkout.checkForSellerOwnedProducts(this.lineItems.Items)
-      await this.checkout.addComment(comment)
       try {
         const payment = this.orderSummaryMeta.StandardLineItemCount
           ? this.getCCPaymentData()
@@ -261,15 +260,31 @@ export class OCMCheckout implements OnInit {
           this.order.ID,
           payment
         )
-        await this.checkout.appendPaymentMethodToOrderXp(order.ID, payment)
-        this.isLoading = false
+        //  Must only patch order AFTER order has been submitted
+        //  to prevent order worksheet data from being cleared.
+        await this.patchSubmittedOrder(order, comment, payment)
         await this.context.order.reset() // get new current order
+        this.isLoading = false
         this.toastrService.success('Order submitted successfully', 'Success')
-        this.context.router.toMyOrderDetails(order.ID)
+        this.context.router.toMyOrderDetails(this.order.ID)
       } catch (e) {
         await this.handleSubmitError(e)
       }
     }
+  }
+
+  async patchSubmittedOrder(
+    order: HSOrder, 
+    comment: string, 
+    payment: OrderCloudIntegrationsCreditCardPayment) {
+    const patchObj = {
+      Comments: comment,
+      xp: {
+        HasSellerProducts: this.lineItems?.Items?.some((li) => li.SupplierID === null),
+        PaymentMethod: payment?.CreditCardID ? 'Credit Card' : 'Purchase Order'
+      }
+    }
+    await Orders.Patch('Outgoing', order.ID, patchObj)
   }
 
   async handleSubmitError(exception: AxiosError): Promise<void> {

--- a/src/UI/Buyer/src/app/services/order/checkout.service.ts
+++ b/src/UI/Buyer/src/app/services/order/checkout.service.ts
@@ -38,26 +38,6 @@ export class CheckoutService {
     private appConfig: AppConfig
   ) {}
 
-  async appendPaymentMethodToOrderXp(
-    orderID: string,
-    ccPayment?: OrderCloudIntegrationsCreditCardPayment
-  ): Promise<void> {
-    const paymentMethod = ccPayment?.CreditCardID
-      ? 'Credit Card'
-      : 'Purchase Order'
-    await Orders.Patch('Outgoing', orderID, {
-      xp: { PaymentMethod: paymentMethod },
-    })
-  }
-
-  async checkForSellerOwnedProducts(lineItems: HSLineItem[]): Promise<void> {
-    const hasSellerProducts = lineItems.some((li) => li.SupplierID === null)
-    await this.patch({ xp: { HasSellerProducts: hasSellerProducts } })
-  }
-
-  async addComment(comment: string): Promise<HSOrder> {
-    return await this.patch({ Comments: comment })
-  }
 
   async setShippingAddress(address: BuyerAddress): Promise<HSOrder> {
     // If a saved address (with an ID) is changed by the user it is attached to an order as a one time address.
@@ -266,10 +246,10 @@ export class CheckoutService {
     return this.order
   }
 
-  private async patch(order: HSOrder): Promise<HSOrder> {
+  private async patch(order: HSOrder, orderID?: string): Promise<HSOrder> {
     this.order = (await Orders.Patch(
       'Outgoing',
-      this.order.ID,
+      orderID || this.order.ID,
       order
     )) as HSOrder
     return this.order


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Once checkout has started we cannot patch the order before the order has been submitted. This PR moves all order patches to after the submit (and does a single patch instead of multiple).

For Reference: [HDS-393](https://four51.atlassian.net/browse/HDS-393) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
