### PR TITLE
update promotion command and add unit tests

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/PromotionCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/PromotionCommand.cs
@@ -1,11 +1,12 @@
 using Flurl.Http;
 using Headstart.Common;
 using ordercloud.integrations.library;
-using OrderCloud.Catalyst;
 using OrderCloud.SDK;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using OrderCloud.Catalyst;
 
 namespace Headstart.API.Commands
 {
@@ -17,49 +18,75 @@ namespace Headstart.API.Commands
     public class PromotionCommand : IPromotionCommand
     {
         private readonly IOrderCloudClient _oc;
-        private readonly AppSettings _settings;
-        public PromotionCommand(IOrderCloudClient oc, AppSettings settings)
+        public PromotionCommand(IOrderCloudClient oc)
         {
             _oc = oc;
-            _settings = settings;
         }
 
         public async Task AutoApplyPromotions(string orderID)
         {
-            try
-            {
-                await _oc.Orders.ValidateAsync(OrderDirection.Incoming, orderID);
-            }
-            catch (Exception ex)
-            {
-                await RemoveOrderPromotions(orderID);
-            }
-
-            var ocAuth = await _oc.AuthenticateAsync();
-
-            var autoEligablePromos = await _oc.Promotions.ListAsync(filters: "xp.Automatic=true");
-            await Throttler.RunAsync(autoEligablePromos.Items, 100, 5, promo =>
-            {
-                //  Not useing the sdk here because we need to ignore errors on promos that are not able to be 
-                //  applied to the order. We need to try this request on every automatic promo.
-                return $"{_settings.OrderCloudSettings.ApiUrl}/v1/orders/Incoming/{orderID}/promotions/{promo.Code}"
-                    .WithOAuthBearerToken(ocAuth.AccessToken)
-                    .AllowAnyHttpStatus().PostAsync(null);
-            });
+            await RemoveAllPromotionsAsync(orderID);
+            var autoEligiblePromos = await _oc.Promotions.ListAsync(filters: "xp.Automatic=true");
+            var requests = autoEligiblePromos.Items.Select(p => TryApplyPromoAsync(orderID, p.Code));
+            await Task.WhenAll(requests);
         }
 
-        private async Task RemoveOrderPromotions(string orderID)
+        private async Task RemoveAllPromotionsAsync(string orderID)
         {
-            var curPromos = await _oc.Orders.ListPromotionsAsync(OrderDirection.Incoming, orderID);
-            if(curPromos?.Items?.Count > 0)
+            // ordercloud does not re-evaluate promotions when line items change
+            // we must remove all promos and re-apply them to ensure promotion discounts are accurate
+            var promos = await _oc.Orders.ListPromotionsAsync(OrderDirection.Incoming, orderID, pageSize: 100);
+            var requests = promos.Items
+                            .DistinctBy(p => p.ID) // the same promo may be applied to multiple line items on one order
+                            .Select(p => RemovePromoAsync(orderID, p));
+            var allTasks = Task.WhenAll(requests);
+
+            try
             {
-                var removeQueue = new List<Task>();
-
-                await Throttler.RunAsync(curPromos.Items, 100, 5, promo =>
+                await allTasks;
+            }
+            catch (Exception)
+            {
+                throw new CatalystBaseException(new ApiError
                 {
-                    return _oc.Orders.RemovePromotionAsync(OrderDirection.Incoming, orderID, promo.Code);
-
+                    ErrorCode = "Promotion.ErrorRemovingAll",
+                    Message = "One or more promotions could not be removed",
+                    Data = allTasks.Exception.InnerExceptions
                 });
+            }
+        }
+
+        private async Task<Order> RemovePromoAsync(string orderID, OrderPromotion promo)
+        {
+            try
+            {
+                return await _oc.Orders.RemovePromotionAsync(OrderDirection.Incoming, orderID, promo.Code);
+            }
+            catch
+            {
+                // this can leave us in a bad state if the promotion can't be deleted but no longer valid
+                throw new CatalystBaseException(new ApiError
+                {
+                    ErrorCode = "Promotion.ErrorRemoving",
+                    Message = $"Unable to remove promotion {promo.Code}",
+                    Data = new
+                    {
+                        Promotion = promo
+                    }
+                });
+            }
+        }
+
+        private async Task TryApplyPromoAsync(string orderID, string promoCode)
+        {
+            try
+            {
+                await _oc.Orders.AddPromotionAsync(OrderDirection.Incoming, orderID, promoCode);
+            }
+            catch
+            {
+                // Its not possible to know if a promo is valid without trying to add it
+                // if it isn't valid it shouldn't show up as an error to the user
             }
         }
     }

--- a/src/Middleware/tests/Headstart.Tests/AutoNSubstituteDataAttribute.cs
+++ b/src/Middleware/tests/Headstart.Tests/AutoNSubstituteDataAttribute.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using AutoFixture.AutoNSubstitute;
+using AutoFixture;
+using AutoFixture.NUnit3;
+using Headstart.Common.Services.ShippingIntegration.Models;
+using Headstart.Models;
+using OrderCloud.SDK;
+using Headstart.Models.Headstart;
+
+namespace Headstart.Tests
+{
+    public class AutoNSubstituteDataAttribute : AutoDataAttribute
+    {
+        public AutoNSubstituteDataAttribute()
+            : base(() => new Fixture().Customize(new HSCompositeCustomization()))
+        {
+
+        }
+    }
+
+    public class HSCompositeCustomization : CompositeCustomization
+    {
+        public HSCompositeCustomization()
+            : base(
+                new OrderCloudModelsCustomization(),
+                new AutoNSubstituteCustomization()
+
+            )
+        {
+        }
+    }
+
+
+    // Autofixture can't handle ordercloud models that use custom xp
+    // due to a bug in the ordercloud sdk  https://github.com/ordercloud-api/ordercloud-dotnet-sdk/issues/60
+    // So as a workaround we are manually providing specific overrides for those types of models here
+    // if this ever does get fixed in the sdk we can delete this whole customization
+    public class OrderCloudModelsCustomization : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+
+            fixture.Customize<HSLocationUserGroup>(c => c
+                .With(x => x.xp, fixture.Create<HSLocationUserGroupXp>()));
+
+            fixture.Customize<HSBuyer>(c => c
+                    .With(x => x.xp, fixture.Create<BuyerXp>()));
+
+            fixture.Customize<HSShipMethod>(c => c
+                    .With(x => x.xp, fixture.Create<ShipMethodXP>()));
+
+            fixture.Customize<HSShipEstimate>(c => c
+                    .With(x => x.xp, fixture.Create<ShipEstimateXP>())
+                    .With(x => x.ShipMethods, fixture.Create<List<HSShipMethod>>()));
+
+            fixture.Customize<HSLineItemProduct>(c => c
+                    .With(x => x.xp, fixture.Create<ProductXp>()));
+
+            fixture.Customize<HSOrderCalculateResponse>(c => c
+                    .With(x => x.xp, fixture.Create<OrderCalculateResponseXp>()));
+
+            fixture.Customize<HSShipEstimateResponse>(c => c
+                    .With(x => x.xp, fixture.Create<ShipEstimateResponseXP>())
+                    .With(x => x.ShipEstimates, fixture.Create<List<HSShipEstimate>>()));
+
+            fixture.Customize<HSLineItem>(c => c
+                    .With(x => x.xp, fixture.Create<LineItemXp>())
+                    .With(x => x.Product, fixture.Create<HSLineItemProduct>())
+                    .With(x => x.ShippingAddress, fixture.Create<HSAddressBuyer>())
+                    .With(x => x.ShipFromAddress, fixture.Create<HSAddressSupplier>()));
+
+            fixture.Customize<HSAddressBuyer>(c => c
+                    .With(x => x.xp, fixture.Create<BuyerAddressXP>()));
+
+            fixture.Customize<HSUser>(c => c
+                    .With(x => x.xp, fixture.Create<UserXp>()));
+
+            fixture.Customize<HSOrder>(c => c
+                    .With(x => x.xp, fixture.Create<OrderXp>())
+                    .With(x => x.FromUser, fixture.Create<HSUser>())
+                    .With(x => x.BillingAddress, fixture.Create<HSAddressBuyer>()));
+
+            fixture.Customize<HSOrderWorksheet>(c => c
+                    .With(x => x.Order, fixture.Create<HSOrder>())
+                    .With(x => x.LineItems, fixture.Create<List<HSLineItem>>())
+                    .With(x => x.ShipEstimateResponse, fixture.Create<HSShipEstimateResponse>())
+                    .With(x => x.OrderCalculateResponse, fixture.Create<HSOrderCalculateResponse>()));
+        }
+    }
+}

--- a/src/Middleware/tests/Headstart.Tests/Headstart.Tests.csproj
+++ b/src/Middleware/tests/Headstart.Tests/Headstart.Tests.csproj
@@ -6,7 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.14.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
+    <PackageReference Include="AutoFixture.NUnit3" Version="4.17.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/src/Middleware/tests/Headstart.Tests/PromotionCommandTests.cs
+++ b/src/Middleware/tests/Headstart.Tests/PromotionCommandTests.cs
@@ -1,0 +1,176 @@
+﻿using AutoFixture;
+using AutoFixture.NUnit3;
+using Headstart.API.Commands;
+using NSubstitute;
+using NUnit.Framework;
+using ordercloud.integrations.library;
+using OrderCloud.Catalyst;
+using OrderCloud.SDK;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Headstart.Tests
+{
+    class PromotionCommandTests
+    {
+        [Test, AutoNSubstituteData]
+        public async Task should_add_all_promos(
+            [Frozen] IOrderCloudClient oc,
+            PromotionCommand sut,
+            string orderID,
+            Task<ListPage<Promotion>> promoList,
+            Task<ListPage<OrderPromotion>> orderpromolist
+        )
+        {
+            // Arrange
+            oc.Promotions.ListAsync()
+                .ReturnsForAnyArgs(promoList);
+            oc.Orders.ListPromotionsAsync(OrderDirection.Incoming, orderID, pageSize: 100)
+                .Returns(orderpromolist);
+
+            // Act
+            await sut.AutoApplyPromotions(orderID);
+
+            // Assert
+            foreach (var promo in promoList.Result.Items)
+            {
+                await oc.Orders.Received().AddPromotionAsync(OrderDirection.Incoming, orderID, promo.Code);
+            }
+        }
+
+        [Test, AutoNSubstituteData]
+        public async Task should_remove_all_promos(
+            [Frozen] IOrderCloudClient oc,
+            PromotionCommand sut,
+            string orderID,
+            Task<ListPage<Promotion>> promoList,
+            Task<ListPage<OrderPromotion>> orderpromolist
+        )
+        {
+            // Arrange
+            oc.Promotions.ListAsync()
+                .ReturnsForAnyArgs(promoList);
+            oc.Orders.ListPromotionsAsync(OrderDirection.Incoming, orderID, pageSize: 100)
+                .Returns(orderpromolist);
+
+            // Act
+            await sut.AutoApplyPromotions(orderID);
+
+            // Assert
+            foreach (var promo in orderpromolist.Result.Items)
+            {
+                await oc.Orders.Received().RemovePromotionAsync(OrderDirection.Incoming, orderID, promo.Code);
+            }
+        }
+
+        [Test, AutoNSubstituteData]
+        public async Task should_remove_all_distinct_promos(
+            [Frozen] IOrderCloudClient oc,
+            PromotionCommand sut,
+            string orderID,
+            Task<ListPage<Promotion>> promoList,
+            ListPage<OrderPromotion> orderpromolist
+        )
+        {
+            // a line item promo may be applied multiple times on an order (once for each line item)
+            // we only want to remove that promo once else we'll get 404's
+            // https://four51.atlassian.net/browse/SEB-1825
+
+            // Arrange
+            orderpromolist.Items = orderpromolist.Items.Select(p => { p.ID = "PROMO1"; p.Code = "PROMOCODE1"; return p; }).ToList();
+            oc.Promotions.ListAsync()
+                .ReturnsForAnyArgs(promoList);
+            oc.Orders.ListPromotionsAsync(OrderDirection.Incoming, orderID, pageSize: 100)
+                .Returns(orderpromolist.ToTask());
+
+            // Act
+            await sut.AutoApplyPromotions(orderID);
+
+            // Assert
+            await oc.Orders.Received(1).RemovePromotionAsync(OrderDirection.Incoming, orderID, "PROMOCODE1");
+        }
+
+        [Test, AutoNSubstituteData]
+        public void should_throw_if_any_errors_removing_promotions(
+            [Frozen] IOrderCloudClient oc,
+            PromotionCommand sut,
+            string orderID,
+            Task<ListPage<Promotion>> promoList,
+            Task<Order> promo1result,
+            Task<ListPage<OrderPromotion>> orderpromolist
+        )
+        {
+            // Arrange
+            var fixture = new Fixture();
+            promoList.Result.Items = fixture.CreateMany<Promotion>(3).ToList();
+            oc.Promotions.ListAsync()
+                .ReturnsForAnyArgs(promoList);
+            oc.Orders.ListPromotionsAsync(OrderDirection.Incoming, orderID, pageSize: 100)
+                .Returns(orderpromolist);
+            oc.Orders.RemovePromotionAsync(OrderDirection.Incoming, orderID, Arg.Any<string>())
+                .Returns(
+                    promo1result,
+                    Task.FromException<Order>(new Exception("mockerror1")),
+                    Task.FromException<Order>(new Exception("mockerror2")));
+
+            // Act
+            var ex = Assert.ThrowsAsync<CatalystBaseException>(async () => await sut.AutoApplyPromotions(orderID));
+
+            // Assert
+            Assert.AreEqual("One or more promotions could not be removed", ex.ApiError.Message);
+            Assert.AreEqual("Promotion.ErrorRemovingAll", ex.ApiError.ErrorCode);
+
+            var innerExceptions = ex.ApiError.Data.To<IReadOnlyCollection<Exception>>();
+            Assert.AreEqual(2, innerExceptions.Count);
+
+            foreach (var e in innerExceptions)
+            {
+                Assert.IsInstanceOf<CatalystBaseException>(e);
+                StringAssert.Contains("Unable to remove promotion", e.Message);
+            }
+        }
+
+        public async Task should_not_throw_if_errors_adding_promotions(
+            [Frozen] IOrderCloudClient oc,
+            PromotionCommand sut,
+            string orderID,
+            Task<ListPage<Promotion>> promoList,
+            Task<ListPage<OrderPromotion>> orderpromolist,
+            Task<Order> removePromoResult,
+            Task<Order> addPromoResult
+        )
+        {
+            // Arrange
+            var fixture = new Fixture();
+            oc.Promotions.ListAsync()
+                .ReturnsForAnyArgs(promoList);
+            orderpromolist.Result.Items = fixture.CreateMany<OrderPromotion>(3).ToList();
+            oc.Orders.ListPromotionsAsync(OrderDirection.Incoming, orderID, pageSize: 100)
+                .Returns(orderpromolist);
+            oc.Orders.RemovePromotionAsync(OrderDirection.Incoming, orderID, Arg.Any<string>())
+                .Returns(removePromoResult);
+            oc.Orders.RemovePromotionAsync(OrderDirection.Incoming, orderID, Arg.Any<string>())
+                .Returns(
+                    addPromoResult,
+                    Task.FromException<Order>(new Exception("mockerror1")),
+                    Task.FromException<Order>(new Exception("mockerror2"))
+                );
+
+            // Act
+            await sut.AutoApplyPromotions(orderID);
+
+            // Assert
+            foreach (var promo in promoList.Result.Items)
+            {
+                await oc.Orders.Received().AddPromotionAsync(OrderDirection.Incoming, orderID, promo.Code);
+            }
+            foreach (var promo in orderpromolist.Result.Items)
+            {
+                await oc.Orders.Received().RemovePromotionAsync(OrderDirection.Incoming, orderID, promo.Code);
+            }
+        }
+    }
+}

--- a/src/Middleware/tests/Headstart.Tests/TestExtensions.cs
+++ b/src/Middleware/tests/Headstart.Tests/TestExtensions.cs
@@ -1,0 +1,42 @@
+﻿using NSubstitute.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Headstart.Tests
+{
+    public static class TestExtensions
+    {
+        public static Task<T> ToTask<T>(this T self)
+        {
+            return Task.FromResult(self);
+        }
+
+        // use this on .Returns when you want to return the first argument
+        // passed to the calling function for example on Saves or Creates generally
+        public static Task<T> FirstArgument<T>(this CallInfo args)
+        {
+            return args.ArgAt<T>(0).ToTask();
+        }
+
+        // pick a single random item out of a list
+        public static T PickRandom<T>(this IEnumerable<T> source)
+        {
+            return source.PickRandom(1).Single();
+        }
+
+        // pick count number of items out of list
+        public static IEnumerable<T> PickRandom<T>(this IEnumerable<T> source, int count)
+        {
+            return source.Shuffle().Take(count);
+        }
+
+        // re-arrange items in a list
+        public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)
+        {
+            return source.OrderBy(x => Guid.NewGuid());
+        }
+    }
+}


### PR DESCRIPTION
## Description
A line item promotion appears multiple times when applied to an order. When the auto-applied promotion logic tries to remove the promotion it tries to remove the same promo multiple times and throws an error

For Reference: [HDS-407](https://four51.atlassian.net/browse/HDS-407)
 I have updated the acceptance criteria on the task so that it can be tested