### PR TITLE
Allow buyer users to create, edit, delete approvals from location management

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/LocationPermissionCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/LocationPermissionCommand.cs
@@ -18,13 +18,13 @@ namespace Headstart.API.Commands
         Task<List<UserGroupAssignment>> ListLocationPermissionAsssignments(string buyerID, string locationID, VerifiedUserContext verifiedUser);
         Task<List<UserGroupAssignment>> ListLocationApprovalPermissionAsssignments(string buyerID, string locationID, VerifiedUserContext verifiedUser);
         Task<decimal> GetApprovalThreshold(string buyerID, string locationID, VerifiedUserContext verifiedUser);
-        Task<decimal> SetLocationApprovalThreshold(string buyerID, string locationID, decimal newApprovalThreshold, VerifiedUserContext verifiedUser);
         Task<ListPage<HSUser>> ListLocationUsers(string buyerID, string locationID, VerifiedUserContext verifiedUser);
         Task<List<UserGroupAssignment>> UpdateLocationPermissions(string buyerID, string locationID, LocationPermissionUpdate locationPermissionUpdate, VerifiedUserContext verifiedUser);
         Task<bool> IsUserInAccessGroup(string locationID, string groupSuffix, VerifiedUserContext verifiedUser);
         Task<List<UserGroupAssignment>> ListUserUserGroupAssignments(string userGroupType, string parentID, string userID, VerifiedUserContext verifiedUser);
         Task<ListPage<HSLocationUserGroup>> ListUserGroupsByCountry(ListArgs<HSLocationUserGroup> args, string buyerID, string userID, VerifiedUserContext verifiedUser);
         Task<ListPage<HSLocationUserGroup>> ListUserGroupsForNewUser(ListArgs<HSLocationUserGroup> args, string buyerID, string userID, VerifiedUserContext verifiedUser);
+        Task<ApprovalRule> SaveApprovalRule(string buyerID, string locationID, ApprovalRule approval, VerifiedUserContext verifiedUser);
     }
 
     public class LocationPermissionCommand : ILocationPermissionCommand
@@ -57,15 +57,10 @@ namespace Headstart.API.Commands
             return threshold;
         }
 
-        public async Task<decimal> SetLocationApprovalThreshold(string buyerID, string locationID, decimal newApprovalThreshold, VerifiedUserContext verifiedUser)
+        public async Task<ApprovalRule> SaveApprovalRule(string buyerID, string locationID, ApprovalRule approval, VerifiedUserContext verifiedUser)
         {
             await EnsureUserIsLocationAdmin(locationID, verifiedUser);
-            var approvalRulePatch = new PartialApprovalRule()
-            { 
-                RuleExpression = $"order.xp.ApprovalNeeded = '{locationID}' & order.Total > {newApprovalThreshold}"
-            };
-            await _oc.ApprovalRules.PatchAsync(buyerID, locationID, approvalRulePatch);
-            return newApprovalThreshold;
+            return await _oc.ApprovalRules.SaveAsync(buyerID, approval.ID, approval);
         }
 
         public async Task<List<UserGroupAssignment>> ListLocationApprovalPermissionAsssignments(string buyerID, string locationID, VerifiedUserContext verifiedUser)

--- a/src/Middleware/src/Headstart.API/Commands/LocationPermissionCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/LocationPermissionCommand.cs
@@ -25,6 +25,7 @@ namespace Headstart.API.Commands
         Task<ListPage<HSLocationUserGroup>> ListUserGroupsByCountry(ListArgs<HSLocationUserGroup> args, string buyerID, string userID, VerifiedUserContext verifiedUser);
         Task<ListPage<HSLocationUserGroup>> ListUserGroupsForNewUser(ListArgs<HSLocationUserGroup> args, string buyerID, string userID, VerifiedUserContext verifiedUser);
         Task<ApprovalRule> SaveApprovalRule(string buyerID, string locationID, ApprovalRule approval, VerifiedUserContext verifiedUser);
+        Task DeleteApprovalRule(string buyerID, string locationID, string approvalID, VerifiedUserContext verifiedUser);
     }
 
     public class LocationPermissionCommand : ILocationPermissionCommand
@@ -61,6 +62,12 @@ namespace Headstart.API.Commands
         {
             await EnsureUserIsLocationAdmin(locationID, verifiedUser);
             return await _oc.ApprovalRules.SaveAsync(buyerID, approval.ID, approval);
+        }
+
+        public async Task DeleteApprovalRule(string buyerID, string locationID, string approvalID, VerifiedUserContext verifiedUser)
+        {
+            await EnsureUserIsLocationAdmin(locationID, verifiedUser);
+            await _oc.ApprovalRules.DeleteAsync(buyerID, approvalID);
         }
 
         public async Task<List<UserGroupAssignment>> ListLocationApprovalPermissionAsssignments(string buyerID, string locationID, VerifiedUserContext verifiedUser)

--- a/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
@@ -111,6 +111,15 @@ namespace Headstart.Common.Controllers
             return await _locationPermissionCommand.SaveApprovalRule(buyerID, buyerLocationID, approval, UserContext);
         }
 
+        [DocName("DELETE Location Approval Rule")]
+        [HttpPut]
+        [OrderCloudUserAuth(ApiRole.Shopper)]
+        [Route("{buyerID}/{buyerLocationID}/approval/{approvalID}")]
+        public async Task DeleteLocationApprovalThreshold(string buyerID, string buyerLocationID, string approvalID)
+        {
+            await _locationPermissionCommand.DeleteApprovalRule(buyerID, buyerLocationID, approvalID, UserContext);
+        }
+
         [DocName("LIST all of a user's user group assignments")]
         [HttpGet, Route("{userGroupType}/{parentID}/usergroupassignments/{userID}"), OrderCloudUserAuth(ApiRole.UserGroupAdmin)]
         public async Task<List<UserGroupAssignment>> ListUserUserGroupAssignments(string userGroupType, string parentID, string userID)

--- a/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/BuyerLocationController.cs
@@ -102,13 +102,13 @@ namespace Headstart.Common.Controllers
             return await _locationPermissionCommand.GetApprovalThreshold(buyerID, buyerLocationID, UserContext);
         }
 
-        [DocName("POST set location approval threshold")]
-        [HttpPost]
+        [DocName("PUT Location Approval Rule")]
+        [HttpPut]
         [OrderCloudUserAuth(ApiRole.Shopper)]
-        [Route("{buyerID}/{buyerLocationID}/approvalthreshold")]
-        public async Task<decimal> SetLocationApprovalThreshold(string buyerID, string buyerLocationID, [FromBody] LocationApprovalThresholdUpdate locationApprovalThresholdUpdate)
+        [Route("{buyerID}/{buyerLocationID}/approval")]
+        public async Task<ApprovalRule> SetLocationApprovalThreshold(string buyerID, string buyerLocationID, [FromBody] ApprovalRule approval)
         {
-            return await _locationPermissionCommand.SetLocationApprovalThreshold(buyerID, buyerLocationID, locationApprovalThresholdUpdate.Threshold, UserContext);
+            return await _locationPermissionCommand.SaveApprovalRule(buyerID, buyerLocationID, approval, UserContext);
         }
 
         [DocName("LIST all of a user's user group assignments")]

--- a/src/Middleware/src/Headstart.Common/Assets/english-translations.json
+++ b/src/Middleware/src/Headstart.Common/Assets/english-translations.json
@@ -1004,6 +1004,7 @@
       "SET_THRESHOLD": "You have the ability to set an order total above which orders will require approval for the users indicated above.",
       "SOME_ORDERS": "Only Orders Over Threshold",
       "THRESHOLD": "Order Approval Threshold",
+      "APPROVAL_ENABLED": "Approval Enabled",
       "USER": "User",
       "USER_IS_ADMINISTRATOR": "You are an approval rule administrator but you are not currently a part of any locations. When you join a location you can assign approval permissions here.",
       "WARNING": "This is a potentially destructive action that affects order approvals."

--- a/src/UI/Buyer/src/app/components/profile/order-approval-permissions/order-approval-permissions.component.html
+++ b/src/UI/Buyer/src/app/components/profile/order-approval-permissions/order-approval-permissions.component.html
@@ -99,96 +99,72 @@
       <p class="font-italic" translate>USERS.USER_MGMT.SET_THRESHOLD</p>
     </div>
     <div class="col-md-7 border-top pt-3">
-      <div class="btn-group" role="group" aria-label="Basic example">
-        <button
-          type="button"
-          (click)="setThreshold(0)"
-          [ngClass]="{ active: currentLocationApprovalThresholdEditable === 0 }"
-          class="btn btn-outline-primary"
-          translate
-        >
-          USERS.USER_MGMT.ALL_ORDERS
-        </button>
-        <button
-          type="button"
-          (click)="
-            setThreshold(currentLocationApprovalThresholdEditable || 100)
-          "
-          [ngClass]="{ active: !!currentLocationApprovalThresholdEditable }"
-          class="btn btn-outline-primary"
-          translate
-        >
-          USERS.USER_MGMT.SOME_ORDERS
-        </button>
-      </div>
       <div class="row mt-3">
-        <div class="input-group mb-3 col-md-6">
-          <div class="input-group-prepend">
-            <span class="input-group-text">$</span>
+        <div class="col-md-5">
+          <div class="form-group text-center">
+            <div class="checkbox">
+              <label for="approvalEnabled">
+                <input
+                  type="checkbox"
+                  id="approvalEnabled"
+                  class="mr-1"
+                  (click)="toggleApproval()"
+                  [checked]="hasApprovalEditable" 
+                />
+                <span translate>Approval Enabled</span>
+              </label>
+            </div>
           </div>
-          <input
-            type="number"
-            min="0"
-            max="100000"
-            value="{{ currentLocationApprovalThresholdEditable }}"
-            class="form-control"
-            (change)="setThresholdFromEvent($event)"
-            aria-label="Amount (to the nearest dollar)"
-          />
-          <div class="input-group-append">
-            <span class="input-group-text">.00</span>
+         
+        </div>
+        <div class="col-md-7">
+          <div *ngIf="hasApprovalEditable" class="input-group mb-3">
+            <div class="input-group-prepend">
+              <span class="input-group-text">$</span>
+            </div>
+            <input
+              type="number"
+              min="0"
+              max="100000"
+              value="{{ currentLocationApprovalThresholdEditable }}"
+              class="form-control"
+              (change)="setThresholdFromEvent($event)"
+              aria-label="Amount (to the nearest dollar)"
+            />
+            <div class="input-group-append">
+              <span class="input-group-text">.00</span>
+            </div>
           </div>
         </div>
-        <div class="col-md-6">
+        <div>
           <button
-            [disabled]="
-              currentLocationApprovalThresholdEditable ===
-              currentLocationApprovalThresholdStatic
-            "
-            class="btn btn-link"
-            *ngIf="
-              currentLocationApprovalThresholdEditable !==
-              currentLocationApprovalThresholdStatic
-            "
-            (click)="
-              currentLocationApprovalThresholdEditable = currentLocationApprovalThresholdStatic
-            "
-          >
-            <span
-              *ngIf="
-                currentLocationApprovalThresholdEditable !==
-                currentLocationApprovalThresholdStatic
-              "
-              translate
-            >
-              USERS.USER_MGMT.CANCEL
-            </span>
-            <span
-              *ngIf="
-                currentLocationApprovalThresholdEditable ===
-                currentLocationApprovalThresholdStatic
-              "
-              translate
-            >
-              USERS.USER_MGMT.NO_CHANGES
-            </span>
-          </button>
-          <button
-            *ngIf="
-              currentLocationApprovalThresholdEditable !==
-              currentLocationApprovalThresholdStatic
-            "
-            [disabled]="
-              currentLocationApprovalThresholdEditable ===
-              currentLocationApprovalThresholdStatic
-            "
-            class="btn btn-outline-primary"
-            (click)="saveNewThreshold()"
+          [disabled]="!approvalChanged()"
+          class="btn btn-link"
+          (click)="resetApprovals()" 
+        >
+          <span
+            *ngIf="approvalChanged()"
             translate
           >
-            USERS.USER_MGMT.SAVE
-          </button>
+            USERS.USER_MGMT.CANCEL
+          </span>
+          <span
+            *ngIf="!approvalChanged()"
+            translate
+          >
+            USERS.USER_MGMT.NO_CHANGES
+          </span>
+        </button>
+        <button
+          *ngIf="approvalChanged()"
+          class="btn btn-outline-primary"
+          (click)="saveNewThreshold()"
+          translate
+        >
+          USERS.USER_MGMT.SAVE
+        </button>
         </div>
+
       </div>
     </div>
   </div>

--- a/src/UI/Buyer/src/app/components/profile/order-approval-permissions/order-approval-permissions.component.html
+++ b/src/UI/Buyer/src/app/components/profile/order-approval-permissions/order-approval-permissions.component.html
@@ -111,7 +111,7 @@
                   (click)="toggleApproval()"
                   [checked]="hasApprovalEditable" 
                 />
-                <span translate>Approval Enabled</span>
+                <span translate>USERS.USER_MGMT.APPROVAL_ENABLED</span>
               </label>
             </div>
           </div>

--- a/src/UI/Buyer/src/app/components/profile/order-approval-permissions/order-approval-permissions.component.ts
+++ b/src/UI/Buyer/src/app/components/profile/order-approval-permissions/order-approval-permissions.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core'
 import { UserGroup, UserGroupAssignment } from 'ordercloud-javascript-sdk'
-import { HSUser } from '@ordercloud/headstart-sdk'
+import { HeadStartSDK, HSUser } from '@ordercloud/headstart-sdk'
 import { ShopperContextService } from 'src/app/services/shopper-context/shopper-context.service'
 
 @Component({
@@ -83,6 +83,8 @@ export class OCMOrderAccessManagement {
       if(ex.status === 404) {
         this.hasApprovalStatic = false
         this.hasApprovalEditable = false
+      } else {
+        throw ex
       }
     } 
   }
@@ -131,11 +133,12 @@ export class OCMOrderAccessManagement {
   }
 
   async saveNewThreshold(): Promise<void> {
+    const approval = HeadStartSDK.Services.BuildApproval(
+      this._locationID, 
+      this.currentLocationApprovalThresholdEditable)
     const buyerID = this._locationID.split('-')[0]
-    const newThreshold = await this.context.userManagementService.setLocationApprovalThreshold(
-      this._locationID,
-      this.currentLocationApprovalThresholdEditable
-    )
+    const newApproval = await HeadStartSDK.ApprovalRules.SaveApprovalRule(buyerID, this._locationID, approval)
+    const newThreshold = parseFloat(newApproval.RuleExpression.split(">")[1])
     this.setApprovalRuleValues(newThreshold)
   }
 

--- a/src/UI/Buyer/src/app/services/user-management/user-management.service.ts
+++ b/src/UI/Buyer/src/app/services/user-management/user-management.service.ts
@@ -100,22 +100,4 @@ export class UserManagementService {
       .get<number>(url, { headers })
       .toPromise()
   }
-
-  async setLocationApprovalThreshold(
-    locationID: string,
-    amount: number
-  ): Promise<number> {
-    const buyerID = this.currentUserService.get().Buyer.ID
-    const headers = new HttpHeaders({
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${Tokens.GetAccessToken()}`,
-    })
-    const body = {
-      Threshold: amount,
-    }
-    const url = `${this.appConfig.middlewareUrl}/buyerlocations/${buyerID}/${locationID}/approvalthreshold`
-    return this.httpClient
-      .post<number>(url, body, { headers })
-      .toPromise()
-  }
 }

--- a/src/UI/SDK/src/api/ApprovalRules.ts
+++ b/src/UI/SDK/src/api/ApprovalRules.ts
@@ -2,7 +2,7 @@ import httpClient from '../utils/HttpClient';
 import { ApprovalRule } from 'ordercloud-javascript-sdk';
 
 export default class ApprovalRules {
-    private impersonating:boolean = false;
+    private impersonating: boolean = false;
 
     /**
     * @ignore
@@ -12,21 +12,31 @@ export default class ApprovalRules {
         this.SaveApprovalRule = this.SaveApprovalRule.bind(this);
     }
 
-   /**
-    * @param buyerID ID of thebuyer
-    * @param locationID ID of the location this approval rule will apply to
-    * @param approval The approval to be created or updated
-    */
+    /**
+     * @param buyerID ID of thebuyer
+     * @param locationID ID of the location this approval rule will apply to
+     * @param approval The approval to be created or updated
+     */
 
-   public async SaveApprovalRule(
-       buyerID: string, 
-       locationID: string, 
-       approval: ApprovalRule, 
-       accessToken?: string): Promise<ApprovalRule> {
-       const impersonating = this.impersonating;
-       this.impersonating = false;
-       return await httpClient.put(`/buyerlocations/${buyerID}/${locationID}/approval`, approval, { params: {  accessToken, impersonating } })
-   }
+    public async SaveApprovalRule(
+        buyerID: string,
+        locationID: string,
+        approval: ApprovalRule,
+        accessToken?: string): Promise<ApprovalRule> {
+        const impersonating = this.impersonating;
+        this.impersonating = false;
+        return await httpClient.put(`/buyerlocations/${buyerID}/${locationID}/approval`, approval, { params: { accessToken, impersonating } })
+    }
+
+    public async DeleteApprovalRule(
+        buyerID: string,
+        locationID: string,
+        approvalID: string,
+        accessToken?: string): Promise<void> {
+        const impersonating = this.impersonating;
+        this.impersonating = false;
+        return await httpClient.put(`/buyerlocations/${buyerID}/${locationID}/approval/${approvalID}`, undefined, { params: { accessToken, impersonating } })
+    }
 
     /**
      * @description 

--- a/src/UI/SDK/src/api/ApprovalRules.ts
+++ b/src/UI/SDK/src/api/ApprovalRules.ts
@@ -1,0 +1,42 @@
+import httpClient from '../utils/HttpClient';
+import { ApprovalRule } from 'ordercloud-javascript-sdk';
+
+export default class ApprovalRules {
+    private impersonating:boolean = false;
+
+    /**
+    * @ignore
+    * not part of public api, don't include in generated docs
+    */
+    constructor() {
+        this.SaveApprovalRule = this.SaveApprovalRule.bind(this);
+    }
+
+   /**
+    * @param buyerID ID of thebuyer
+    * @param locationID ID of the location this approval rule will apply to
+    * @param approval The approval to be created or updated
+    */
+
+   public async SaveApprovalRule(
+       buyerID: string, 
+       locationID: string, 
+       approval: ApprovalRule, 
+       accessToken?: string): Promise<ApprovalRule> {
+       const impersonating = this.impersonating;
+       this.impersonating = false;
+       return await httpClient.put(`/buyerlocations/${buyerID}/${locationID}/approval`, approval, { params: {  accessToken, impersonating } })
+   }
+
+    /**
+     * @description 
+     * enables impersonation by calling the subsequent method with the stored impersonation token
+     * 
+     * @example
+     * ExchangeRates.As().List() // lists ExchangeRates using the impersonated users' token
+     */
+    public As(): this {
+        this.impersonating = true;
+        return this;
+    }
+}

--- a/src/UI/SDK/src/api/Service.ts
+++ b/src/UI/SDK/src/api/Service.ts
@@ -1,11 +1,13 @@
-import { ListPage } from "../models";
+import { ListPage, OrderApproval } from "../models";
 import { flatten, range } from 'lodash'
+import {ApprovalRule} from 'ordercloud-javascript-sdk'
 
 
 export default class Services {
 
     constructor() {
         this.ListAll = this.ListAll.bind(this)
+        this.BuildApproval = this.BuildApproval.bind(this)
     }
     
     /**
@@ -39,6 +41,23 @@ export default class Services {
         return {
             Items: flatten([result1, ...results].map((r) => r.Items)),
             Meta: result1.Meta,
+        }
+    }
+
+    /**
+    * @param locationID ID of the location that the approval rule applies to
+    * @param orderThreshold Order total threshold for orders to be subject to this rule
+    */
+    public BuildApproval(locationID: string, orderThreshold?: number): ApprovalRule {
+        return {
+            ID: locationID,
+            Name: locationID + ' General Location Approval Rule',
+            Description: "General approval rule for location. " + 
+                "Every order over a certain limit will require approval " + 
+                "for the designated group of users.",
+            ApprovingGroupID: `${locationID}-OrderApprover`,
+            RuleExpression: 'order.xp.ApprovalNeeded = ' + locationID + 
+                ' & order.Total > ' + (orderThreshold || 0) 
         }
     }
 }

--- a/src/UI/SDK/src/api/index.ts
+++ b/src/UI/SDK/src/api/index.ts
@@ -35,6 +35,7 @@ import Tokens from './Tokens';
 import Upload from './Upload';
 import Assets from './Assets';
 import Services from './Service';
+import ApprovalRules from './ApprovalRules';
 
 export { HeadStartSDK }
 
@@ -75,7 +76,8 @@ const HeadStartSDK: HeadStartSDK = {
     Auth: new Auth(),
     Tokens: new Tokens(),
     Upload: new Upload(),
-    Services: new Services()
+    Services: new Services(),
+    ApprovalRules: new ApprovalRules()
 }
 
 interface HeadStartSDK {
@@ -115,5 +117,6 @@ interface HeadStartSDK {
     Auth: Auth,
     Tokens: Tokens,
     Upload: Upload,
-    Services: Services
+    Services: Services,
+    ApprovalRules: ApprovalRules
 }

--- a/src/UI/Seller/src/app/buyers/components/locations/buyer-location-approvals/buyer-location-approvals.component.ts
+++ b/src/UI/Seller/src/app/buyers/components/locations/buyer-location-approvals/buyer-location-approvals.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { FormControl, FormGroup } from "@angular/forms";
-import { HSBuyerLocation, OrderApproval } from "@ordercloud/headstart-sdk";
+import { HeadStartSDK, HSBuyerLocation, OrderApproval } from "@ordercloud/headstart-sdk";
 import { ApprovalRule, ApprovalRules } from "ordercloud-javascript-sdk";
 
 
@@ -75,16 +75,10 @@ export class BuyerLocationApprovals {
             const buyerID = this.buyerGroup?.UserGroup?.ID?.split("-")[0]
             if(this.approvalEnabled) {
                 const form = this.approvalForm.getRawValue()
-                const editedApproval: ApprovalRule = {
-                    ID: this._approvalRule?.ID || this.buyerGroup?.UserGroup?.ID,
-                    Name: this.buyerGroup?.UserGroup?.ID + ' General Location Approval Rule',
-                    Description: "General approval rule for location. " + 
-                        "Every order over a certain limit will require approval " + 
-                        "for the designated group of users.",
-                    ApprovingGroupID: `${this.buyerGroup?.UserGroup?.ID}-OrderApprover`,
-                    RuleExpression: 'order.xp.ApprovalNeeded = ' + this.buyerGroup?.UserGroup?.ID + 
-                        ' & order.Total > ' + (form.OrderThreshold || 0) 
-                }
+                const editedApproval = HeadStartSDK.Services.BuildApproval(
+                    this._approvalRule?.ID || this.buyerGroup?.UserGroup?.ID,
+                    form.OrderThreshold
+                )
                 const update = await ApprovalRules.Save(buyerID, editedApproval.ID, editedApproval)
                 this.approvalUpdated.emit(update)
             } else {


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
1. Updated the UI (removed some buttons). Now you only select Approval enabled, and enter an order total threshold.
2. Buyer users can edit, create, and delete their approval (if they have admin permissions) for their locations.

For Reference: [HDS-397](https://four51.atlassian.net/browse/HDS-397) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
