### PR TITLE
HDS-393 move order patching to integration event

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/PostSubmitCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/PostSubmitCommand.cs
@@ -315,6 +315,14 @@ namespace Headstart.API.Commands
         private async Task<Tuple<List<HSOrder>, HSOrderWorksheet, List<ProcessResultAction>>> HandlingForwarding(HSOrderWorksheet orderWorksheet)
         {
             var activities = new List<ProcessResultAction>();
+            // patch order
+            var patchAction = await ProcessActivityCall(
+                ProcessType.Patching,
+                "OrderCloud API Patch Order After Submit",
+                PatchOrder(orderWorksheet)
+                );
+            activities.Add(patchAction);
+
             // forwarding
             var (forwardAction, forwardedOrders) = await ProcessActivityCall(
                 ProcessType.Forwarding,
@@ -340,6 +348,20 @@ namespace Headstart.API.Commands
             activities.Add(getAction);
 
             return await Task.FromResult(new Tuple<List<HSOrder>, HSOrderWorksheet, List<ProcessResultAction>>(hsOrders, hsOrderWorksheet, activities));
+        }
+
+        public async Task PatchOrder(HSOrderWorksheet buyerOrder)
+        {
+            var payment = (await _oc.Payments.ListAsync(OrderDirection.Incoming, buyerOrder.Order.ID))?.Items?.FirstOrDefault();
+            var patchObj = new PartialOrder()
+            {
+                xp = new OrderXp()
+                {
+                    HasSellerProducts = buyerOrder.LineItems.Any(li => li.SupplierID == null),
+                    PaymentMethod = payment.Type == PaymentType.CreditCard ? "Credit Card" : "Purchase Order"
+                }
+            };
+            await _oc.Orders.PatchAsync(OrderDirection.Incoming, buyerOrder.Order.ID, patchObj);
         }
 
         public  async Task<List<HSOrder>> CreateOrderRelationshipsAndTransferXP(HSOrderWorksheet buyerOrder, List<Order> supplierOrders)

--- a/src/Middleware/src/Headstart.Common/Models/Headstart/HSOrderSubmitResponse.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Headstart/HSOrderSubmitResponse.cs
@@ -31,6 +31,7 @@ namespace Headstart.Models.Headstart
     [JsonConverter(typeof(StringEnumConverter))]
     public enum ProcessType
     {
+        Patching,
         Forwarding,
         Notification,
         Accounting,

--- a/src/UI/Buyer/src/app/components/checkout/checkout/checkout.component.ts
+++ b/src/UI/Buyer/src/app/components/checkout/checkout/checkout.component.ts
@@ -260,9 +260,7 @@ export class OCMCheckout implements OnInit {
           this.order.ID,
           payment
         )
-        //  Must only patch order AFTER order has been submitted
-        //  to prevent order worksheet data from being cleared.
-        await this.patchSubmittedOrder(order, comment, payment)
+        await this.checkout.patch({Comments: comment}, order.ID)
         await this.context.order.reset() // get new current order
         this.isLoading = false
         this.toastrService.success('Order submitted successfully', 'Success')
@@ -271,20 +269,6 @@ export class OCMCheckout implements OnInit {
         await this.handleSubmitError(e)
       }
     }
-  }
-
-  async patchSubmittedOrder(
-    order: HSOrder, 
-    comment: string, 
-    payment: OrderCloudIntegrationsCreditCardPayment) {
-    const patchObj = {
-      Comments: comment,
-      xp: {
-        HasSellerProducts: this.lineItems?.Items?.some((li) => li.SupplierID === null),
-        PaymentMethod: payment?.CreditCardID ? 'Credit Card' : 'Purchase Order'
-      }
-    }
-    await this.checkout.patch(patchObj, order.ID)
   }
 
   async handleSubmitError(exception: AxiosError): Promise<void> {

--- a/src/UI/Buyer/src/app/components/checkout/checkout/checkout.component.ts
+++ b/src/UI/Buyer/src/app/components/checkout/checkout/checkout.component.ts
@@ -260,6 +260,8 @@ export class OCMCheckout implements OnInit {
           this.order.ID,
           payment
         )
+        //  Do all patching of order XP values in the OrderSubmit integration event
+        //  Patching order XP before order is submitted will clear out order worksheet data
         await this.checkout.patch({Comments: comment}, order.ID)
         await this.context.order.reset() // get new current order
         this.isLoading = false


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Move some order patches into the ordersubmit integration event to ensure that they happen after order is submitted. 

For Reference: [HDS-393](https://four51.atlassian.net/browse/HDS-393) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
