### PR TITLE
HDS-406

### DIFF
--- a/src/UI/Seller/src/app/orders/components/line-item-table/line-item-table.component.ts
+++ b/src/UI/Seller/src/app/orders/components/line-item-table/line-item-table.component.ts
@@ -76,8 +76,9 @@ export class LineItemTableComponent {
       (order) => order.ID === `${salesOrderID}-${lineItem.SupplierID}`
     )
     const shipFromID = lineItem.ShipFromAddressID
-    const shipMethod = (
-      supplierOrder?.xp?.SelectedShipMethodsSupplierView || []
+    const shipMethod = ( lineItem.SupplierID === null ?
+      (this._order?.xp?.SelectedShipMethodsSupplierView || []) :
+      (supplierOrder?.xp?.SelectedShipMethodsSupplierView || [])
     ).find((sm) => sm.ShipFromAddressID === shipFromID)
     if (shipMethod == null) return 'No Data'
     const name = shipMethod.Name.replace(/_/g, ' ')


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
1. Orders with a seller owned line item will not have a corresponding supplier order for that item.
2. In this case Store the selected ship on the buyer order.
3. Move some other order patch functionality into the same order patch in the CreateRelationshipAndTransferXp method.

For Reference: [HDS-406](https://four51.atlassian.net/browse/HDS-406) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
