### PR TITLE
Hds 412

### DIFF
--- a/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.ts
+++ b/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.ts
@@ -389,13 +389,16 @@ export class ProductEditComponent implements OnInit, OnDestroy {
     if (this.productService.checkIfCreatingNew()) {
       return false
     }
-    if (superHSProduct.Product?.DefaultSupplierID) {
-      if (
-        this.userContext?.Me?.Supplier?.ID ===
-        superHSProduct?.Product?.DefaultSupplierID
-      ) {
-        return false
-      }
+
+    if (!superHSProduct.Product?.DefaultSupplierID) {
+      return false
+    }
+
+    if (
+      this.userContext?.Me?.Supplier?.ID ===
+      superHSProduct?.Product?.DefaultSupplierID
+    ) {
+      return false
     }
     return true
   }

--- a/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.ts
+++ b/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.ts
@@ -14,6 +14,7 @@ import {
   Address,
   SupplierAddresses,
   AdminAddresses,
+  MeUser,
 } from 'ordercloud-javascript-sdk'
 import {
   FormGroup,
@@ -48,6 +49,7 @@ import {
   TaxCode,
   AssetType,
   ImageAsset,
+  HSProduct,
 } from '@ordercloud/headstart-sdk'
 import { Location } from '@angular/common'
 import { TabIndexMapper, setProductEditTab } from './tab-mapper'
@@ -390,14 +392,19 @@ export class ProductEditComponent implements OnInit, OnDestroy {
       return false
     }
 
-    if (!superHSProduct.Product?.DefaultSupplierID) {
+    const currentUser: MeUser = this.userContext.Me
+    const product: HSProduct = superHSProduct?.Product
+    const isSellerUser: boolean = this.userContext.UserType === 'SELLER'
+
+    if (!product?.DefaultSupplierID && isSellerUser) {
       return false
     }
 
-    if (
-      this.userContext?.Me?.Supplier?.ID ===
-      superHSProduct?.Product?.DefaultSupplierID
-    ) {
+    if (currentUser?.Supplier?.ID === product?.DefaultSupplierID) {
+      return false
+    }
+
+    if (isSellerUser && product?.OwnerID === currentUser?.Seller?.ID) {
       return false
     }
     return true


### PR DESCRIPTION
Changing product edit visibility rules. the rules for when products are editable are as follows:

1. when creating a new product
2. when product has no default supplier ID and when the user is a seller
3. if the user's supplier ID is the product's default supplier ID
4. if the user's sellerID is the product's ownerID and when the user is a Seller.

Slight redundancies in a few of those cases to avoid edge cases.

For Reference: [HDS-412](https://four51.atlassian.net/browse/HDS-412) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
