### PR TITLE
default currency to USD if not defined

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/MeProductCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/MeProductCommand.cs
@@ -70,7 +70,7 @@ namespace Headstart.API.Commands
 			var exchangeRates = await exchangeRatesRequest;
 
 			var markedupProduct = ApplyBuyerProductPricing(superHsProduct.Product, defaultMarkupMultiplier, exchangeRates);
-			var productCurrency = superHsProduct.Product.xp.Currency;
+			var productCurrency = superHsProduct.Product.xp.Currency ?? CurrencySymbol.USD;
 			var markedupSpecs = ApplySpecMarkups(superHsProduct.Specs.ToList(), productCurrency, exchangeRates);
 		
 			superHsProduct.Product = markedupProduct;


### PR DESCRIPTION
## Description
This was causing error on product detail page when trying to view a product where xp.Currency was null or not defined
