### PR TITLE
Fix a few bugs Christie found

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
@@ -72,6 +72,7 @@ namespace Headstart.API.Commands
             new XpIndex { ThingType = XpThingType.UserGroup, Key = "Type" },
             new XpIndex { ThingType = XpThingType.UserGroup, Key = "Role" },
             new XpIndex { ThingType = XpThingType.UserGroup, Key = "Country" },
+            new XpIndex { ThingType = XpThingType.UserGroup, Key = "CatalogAssignments" },
             new XpIndex { ThingType = XpThingType.Company, Key = "Data.ServiceCategory" },
             new XpIndex { ThingType = XpThingType.Company, Key = "Data.VendorLevel" },
             new XpIndex { ThingType = XpThingType.Company, Key = "SyncFreightPop" },

--- a/src/Middleware/src/Headstart.API/Commands/HSCatalogCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/HSCatalogCommand.cs
@@ -81,11 +81,11 @@ namespace Headstart.API.Commands.Crud
 			var allUserAssignments = await _oc.UserGroups.ListAllUserAssignmentsAsync(buyerID: buyerID, userID: userID);
 			var assignedGroupIDs = allUserAssignments?.Select(assignment => assignment?.UserGroupID)?.ToList();
 			var assignedGroups = await _oc.UserGroups.ListAsync<HSLocationUserGroup>(buyerID: buyerID, filters: $"ID={string.Join("|", assignedGroupIDs)}", pageSize: 100);
-			var existingCatalogs = await _oc.UserGroups.ListAsync(buyerID, filters: "xp.Type=Catalog", pageSize: 100);
+			var existingCatalogs = await _oc.UserGroups.ListAsync<HSLocationUserGroup>(buyerID, filters: "xp.Type=Catalog", pageSize: 100);
 			
 			// from the data extract the relevant catalogIDs
-			var expectedAssignedCatalogIDs = assignedGroups?.Items?.Where(item => (item?.xp?.Type == "BuyerLocation"))?.SelectMany(c => c?.xp?.CatalogAssignments);
-			var actualAssignedCatalogIDs = assignedGroups?.Items?.Where(item => item?.xp?.Type == "Catalog")?.Select(c => c.ID)?.ToList();
+			var expectedAssignedCatalogIDs = assignedGroups.Items?.Where(item => (item?.xp?.Type == "BuyerLocation"))?.SelectMany(c => c?.xp?.CatalogAssignments);
+			var actualAssignedCatalogIDs = assignedGroups.Items?.Where(item => item?.xp?.Type == "Catalog")?.Select(c => c.ID)?.ToList();
 			var existingCatalogIDs = existingCatalogs.Items.Select(x => x.ID);
 
 			// analyze list to determine the catalogids to remove, and the list of catalogids to add

--- a/src/UI/Seller/src/app/buyers/components/buyers/buyer.service.ts
+++ b/src/UI/Seller/src/app/buyers/components/buyers/buyer.service.ts
@@ -9,7 +9,6 @@ import { ListArgs } from '@ordercloud/headstart-sdk'
 export const BUYER_SUB_RESOURCE_LIST = [
   { route: 'users', display: 'ADMIN.NAV.USERS' },
   { route: 'locations', display: 'ALIAS.BUYER_LOCATIONS' },
-  { route: 'payments', display: 'ADMIN.NAV.PAYMENTS' },
   { route: 'approvals', display: 'ADMIN.NAV.APPROVALS' },
   { route: 'catalogs', display: 'ADMIN.NAV.CATALOGS' },
   { route: 'categories', display: 'ADMIN.NAV.CATEGORIES' },

--- a/src/UI/Seller/src/app/buyers/components/catalogs/buyer-catalog.service.ts
+++ b/src/UI/Seller/src/app/buyers/components/catalogs/buyer-catalog.service.ts
@@ -1,16 +1,11 @@
 import { Injectable } from '@angular/core'
 import { Router, ActivatedRoute } from '@angular/router'
-import {
-  Buyer,
-  ListPage,
-  OcUserGroupService,
-  UserGroup,
-} from '@ordercloud/angular-sdk'
+import { Buyer } from '@ordercloud/angular-sdk'
 import { ResourceCrudService } from '@app-seller/shared/services/resource-crud/resource-crud.service'
 import { BUYER_SUB_RESOURCE_LIST } from '../buyers/buyer.service'
 import { CurrentUserService } from '@app-seller/shared/services/current-user/current-user.service'
 import { UserGroups } from 'ordercloud-javascript-sdk'
-import { ListArgs } from '@ordercloud/headstart-sdk'
+import { HSLocationUserGroup, ListArgs } from '@ordercloud/headstart-sdk'
 
 @Injectable({
   providedIn: 'root',
@@ -44,5 +39,46 @@ export class BuyerCatalogService extends ResourceCrudService<Buyer> {
   addIntrinsicListArgs(options: ListArgs): ListArgs {
     options.filters = { 'xp.Type': 'Catalog' }
     return options
+  }
+
+  // overriding the normal delete resource method because
+  // additionally we need to do some cleanup for any
+  // location that references the catalog to be deleted
+  async deleteResource(resourceID: string): Promise<null> {
+    const buyerID = this.getBuyerID()
+    const locationsWithCatalogAssigned = await UserGroups.List<HSLocationUserGroup>(
+      buyerID,
+      {
+        filters: {
+          'xp.Type': 'BuyerLocation',
+          'xp.CatalogAssignments': resourceID,
+        },
+      }
+    )
+    const requests = locationsWithCatalogAssigned.Items.map((location) => {
+      location.xp.CatalogAssignments = location.xp.CatalogAssignments.filter(
+        (x) => x !== resourceID
+      )
+      return UserGroups.Patch(buyerID, location.ID, {
+        xp: {
+          CatalogAssignments: location.xp.CatalogAssignments,
+        },
+      })
+    })
+    await Promise.all(requests)
+
+    const args = await this.createListArgs([resourceID])
+    await this.ocService.Delete(...args)
+    this.resourceSubject.value.Items = this.resourceSubject.value.Items.filter(
+      (i: any) => i.ID !== resourceID
+    )
+    this.resourceSubject.next(this.resourceSubject.value)
+    return
+  }
+
+  getBuyerID(): string {
+    const urlPieces = this.router.url.split('/')
+    const indexOfParent = urlPieces.indexOf(`${this.primaryResourceLevel}`)
+    return urlPieces[indexOfParent + 1]
   }
 }


### PR DESCRIPTION
## Description
There was an issue where a buyer location was referencing a catalog that no longer existed. This caused issues when you tried to update a user's locations because it would try to assign that non-existent catalog. I've fixed this with a two-pronged attack
1. When updating user locations, first check if the catalog exists before trying to assign it
2. When a catalog is deleted, search for any buyer locations that reference it and update it to remove that reference

Also fixed a bug where a link to payments existed but payments management no longer exists in the application

For Reference: [HDS-314](https://four51.atlassian.net/browse/HDS-314)

- [x] I have updated the acceptance criteria on the task so that it can be tested
