### PR TITLE
HDS-453 - remove personalization on Admin product-edit

### DIFF
--- a/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.html
+++ b/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.html
@@ -178,41 +178,6 @@
                       </select>
                     </div>
                   </div>
-                  <hr />
-                  <h6 class="font-weight-medium">
-                    Personalization
-                    <small class="d-block">
-                      <fa-icon
-                        class="color-beige"
-                        [icon]="faExclamationCircle"
-                      ></fa-icon>
-                      <span translate>
-                        ADMIN.PRODUCT_EDIT.ARTWORK_REQUIRED_INFO</span
-                      >
-                    </small>
-                  </h6>
-                  <div class="form-group">
-                    <div class="custom-control custom-checkbox">
-                      <input
-                        type="checkbox"
-                        class="custom-control-input"
-                        formControlName="ArtworkRequired"
-                        (input)="
-                          handleUpdateProduct(
-                            $event,
-                            'Product.xp.ArtworkRequired'
-                          )
-                        "
-                        id="ArtworkRequired"
-                      />
-                      <label
-                        class="custom-control-label"
-                        for="ArtworkRequired"
-                        translate
-                        >ADMIN.PRODUCT_EDIT.ARTWORK_REQUIRED</label
-                      >
-                    </div>
-                  </div>
                   <!-- /Product Name -->
                   <hr />
                   <h6 class="font-weight-medium" translate>


### PR DESCRIPTION

Variable products were removed from the buyer side, but the admin checkbox was still an option which would leave things in a bad state. removing it.

For Reference: [HDS-453](https://four51.atlassian.net/browse/HDS-453)

- [x] I have updated the acceptance criteria on the task so that it can be tested
