### PR TITLE
HDS-463 - default payment method to Credit card if none is provided in the config

### DIFF
--- a/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
+++ b/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
@@ -66,7 +66,7 @@ export class OCMCheckoutPayment implements OnInit {
   }
 
   getAcceptedPaymentMethods(): string[] {
-    if (this.appConfig.acceptedPaymentMethods.length < 1) {
+    if (this.appConfig?.acceptedPaymentMethods?.length < 1) {
       return [AcceptedPaymentTypes.CreditCard]
     }
     return this.appConfig.acceptedPaymentMethods;

--- a/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
+++ b/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
@@ -60,9 +60,16 @@ export class OCMCheckoutPayment implements OnInit {
   ngOnInit(): void {
     this._orderCurrency = this.context.currentUser.get().Currency
     this.setOrderPromos()
-    this._acceptedPaymentMethods = this.appConfig.acceptedPaymentMethods
+    this._acceptedPaymentMethods = this.getAcceptedPaymentMethods()
     this.selectedPaymentMethod = this._acceptedPaymentMethods?.[0] as AcceptedPaymentTypes
     this.createPromoForm(this.promoCode)
+  }
+
+  getAcceptedPaymentMethods(): string[] {
+    if (this.appConfig.acceptedPaymentMethods.length < 1) {
+      return [AcceptedPaymentTypes.CreditCard]
+    }
+    return this.appConfig.acceptedPaymentMethods;
   }
 
   createPromoForm(promoCode: string): void {


### PR DESCRIPTION
default payment method to Credit card if none is provided in the config.

For Reference: [HDS-463](https://four51.atlassian.net/browse/HDS-463)

if no payment type is set in the config, default to credit cards so checkout isn't stopped.
