### PR TITLE
HDS-464 add storefrontName to config files

### DIFF
--- a/src/UI/Buyer/src/app/config/app.config.ts
+++ b/src/UI/Buyer/src/app/config/app.config.ts
@@ -18,6 +18,7 @@ export const ocAppConfig: AppConfig = {
   anonymousShoppingEnabled: true,
   appInsightsInstrumentationKey: environment.appInsightsInstrumentationKey,
   acceptedPaymentMethods: environment.acceptedPaymentMethods,
+  storefrontName: environment.storefrontName,
   scope: [
     'MeAddressAdmin',
     'AddressAdmin', // Only for location owners

--- a/src/UI/Buyer/src/app/models/environment.types.ts
+++ b/src/UI/Buyer/src/app/models/environment.types.ts
@@ -57,7 +57,8 @@ export interface EnvironmentConfig {
   orderCloudApiUrl: string
   theme?: Theme
   appInsightsInstrumentationKey?: string
-  acceptedPaymentMethods: string[]
+  acceptedPaymentMethods?: string[]
+  storefrontName?: string
 }
 
 export class AppConfig {
@@ -128,5 +129,10 @@ export class AppConfig {
   /**
    * Payment methods that are accepted for the buyer/storefront
    */
-  acceptedPaymentMethods: string[]
+  acceptedPaymentMethods?: string[]
+
+  /**
+   * Name of the storefront (API Client) being implemented in this app. This is used in automatic deployments
+   */
+  storefrontName?: string
 }

--- a/src/UI/Buyer/src/main.ts
+++ b/src/UI/Buyer/src/main.ts
@@ -4,6 +4,15 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic'
 import { AppModule } from './app/app.module'
 import { environment } from './environments/environment.local'
 
+declare var __webpack_public_path__: string;
+
+//  set the __webpack_public_path__ depending on if the first path after the base url is the storefront name.
+//  Do this for automatic deployments in which files are copied to a folder in blob storage named the storefront name
+//  This allows assets to be referenced correctly.
+if (window.location.href.split('/')[1] === environment.storefrontName) {
+  __webpack_public_path__ = environment.storefrontName
+}
+
 if (environment.hostedApp) {
   enableProdMode()
 }


### PR DESCRIPTION
Add storefrontName to application configuration
Then we can check if the first part of the route is the storefront name and set the __webpack_public_path__ if necessary. 

## Description

For Reference: [HDS-464](https://four51.atlassian.net/browse/HDS-464) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
