### PR TITLE
HDS-464 add stylesheet attribute to Link tag

### DIFF
--- a/src/UI/Buyer/src/index.html
+++ b/src/UI/Buyer/src/index.html
@@ -82,6 +82,7 @@
       ) {
         var newLink = document.createElement('link')
         newLink.setAttribute('href', prefix + '/' + linkHref)
+        newLink.setAttribute('rel', 'stylesheet')
         document.head.appendChild(newLink)
       }
     }


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Add the stylesheet attribute to the link tag. Everything working so far but for some reason the css is not being brought into the /storefront route version.

For Reference: [HDS-464](https://four51.atlassian.net/browse/HDS-464) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
