### PR TITLE
HDS-464 do not use app configs to keep the storefrontName variable.

### DIFF
--- a/src/UI/Buyer/src/app/config/app.config.ts
+++ b/src/UI/Buyer/src/app/config/app.config.ts
@@ -18,7 +18,6 @@ export const ocAppConfig: AppConfig = {
   anonymousShoppingEnabled: true,
   appInsightsInstrumentationKey: environment.appInsightsInstrumentationKey,
   acceptedPaymentMethods: environment.acceptedPaymentMethods,
-  storefrontName: environment.storefrontName,
   scope: [
     'MeAddressAdmin',
     'AddressAdmin', // Only for location owners

--- a/src/UI/Buyer/src/app/models/environment.types.ts
+++ b/src/UI/Buyer/src/app/models/environment.types.ts
@@ -58,7 +58,6 @@ export interface EnvironmentConfig {
   theme?: Theme
   appInsightsInstrumentationKey?: string
   acceptedPaymentMethods?: string[]
-  storefrontName?: string
 }
 
 export class AppConfig {
@@ -130,9 +129,4 @@ export class AppConfig {
    * Payment methods that are accepted for the buyer/storefront
    */
   acceptedPaymentMethods?: string[]
-
-  /**
-   * Name of the storefront (API Client) being implemented in this app. This is used in automatic deployments
-   */
-  storefrontName?: string
 }

--- a/src/UI/Buyer/src/main.ts
+++ b/src/UI/Buyer/src/main.ts
@@ -3,22 +3,17 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic'
 
 import { AppModule } from './app/app.module'
 import { environment } from './environments/environment.deploy'
-import { environment as environmentLocal } from './environments/environment.local'
 
 declare var __webpack_public_path__: string;
 
 //  set the __webpack_public_path__ depending on if the first path after the base url is the storefront name.
 //  Do this for automatic deployments in which files are copied to a folder in blob storage named the storefront name
 //  This allows assets to be referenced correctly.
-console.log('deployed environment')
-console.log(environment)
+const prefix = '<PLACEHOLDER>'
 
-console.log('local environment')
-console.log(environmentLocal)
-
-if (document.location.pathname.split('/')[1] === environment.storefrontName) {
+if (document.location.pathname.split('/')[1] === prefix) {
   console.log("setting __webpack_public_path__")
-  __webpack_public_path__ = environment.storefrontName
+  __webpack_public_path__ = prefix
 }
 
 if (environment.hostedApp) {


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
Do not use the app configs to keep the storefrontName varaible. Changing this value has no effect on what is read/used by the app. Instead try setting a placeholder and changing it to the name of the api client when files are copied over (same as what is done in index.html).

For Reference: [HDS-464](https://four51.atlassian.net/browse/HDS-464) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
