### PR TITLE
SEB-1977 ensure quantity is not cut off when over 1000

### DIFF
--- a/src/UI/Buyer/src/app/components/products/product-details/product-details.component.html
+++ b/src/UI/Buyer/src/app/components/products/product-details/product-details.component.html
@@ -101,7 +101,7 @@
           >
           <div class="d-flex flex-row">
             <ocm-quantity-input
-              class="d-inline-block mb-3 mr-3"
+              class="d-inline-block mb-3 mr-3 flex-shrink-0"
               (qtyChange)="qtyChange($event.detail)"
               [product]="_product"
               [priceSchedule]="_product.PriceSchedule"

--- a/src/UI/Buyer/src/app/components/products/product-details/product-details.component.scss
+++ b/src/UI/Buyer/src/app/components/products/product-details/product-details.component.scss
@@ -5,3 +5,7 @@
 .product-qty-input {
     max-width: 100px
 }
+
+.flex-shrink-0 {
+    flex-shrink: 0;
+}


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
This is an SEB task I am adding here as well. If quantity is four digits the fourth digit will be cut off. Adding a `flex-shrink: 0` property to the component to prevent this.

For Reference: [SEB-1977](https://four51.atlassian.net/browse/SEB-1977) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
