### PR TITLE
Taxjar Prevents Startup

### DIFF
--- a/src/Middleware/integrations/ordercloud.integrations.taxjar/TaxJarCommand.cs
+++ b/src/Middleware/integrations/ordercloud.integrations.taxjar/TaxJarCommand.cs
@@ -30,6 +30,11 @@ namespace ordercloud.integrations.taxjar
 
 		public TaxJarCommand(TaxJarConfig config)
 		{
+			if (string.IsNullOrWhiteSpace(config.ApiKey))
+			{
+				return;
+			}
+
 			var apiUrl = config.Environment == TaxJarEnvironment.Production ? TaxjarConstants.DefaultApiUrl : TaxjarConstants.SandboxApiUrl;
 			_client = new TaxjarApi(config.ApiKey, new { apiUrl });
 		}


### PR DESCRIPTION
With the updated tax integrations implemetation, tax providers are now instantiated regardless of which TaxProvider has been configured and throws an ArgumentException if the TaxJar configuration is not provided.

Added a simple condition to prevent the TaxjarApi from instantiating if the ApiKey is not configured.

This may be considered a temporary workaround and further review of the tax integrations may be required.