### PR TITLE
Applied null-condition operators to address xp properties.

### DIFF
--- a/src/UI/Seller/src/app/buyers/components/locations/buyer-location-edit/buyer-location-edit.component.ts
+++ b/src/UI/Seller/src/app/buyers/components/locations/buyer-location-edit/buyer-location-edit.component.ts
@@ -106,15 +106,14 @@ export class BuyerLocationEditComponent implements OnInit {
         Validators.required
       ),
       Phone: new FormControl(buyerLocation.Address.Phone, ValidatePhone),
-      Email: new FormControl(buyerLocation.Address.xp.Email, ValidateEmail),
-      LocationID: new FormControl(buyerLocation.Address.xp.LocationID),
+      Email: new FormControl(buyerLocation.Address.xp?.Email, ValidateEmail),
+      LocationID: new FormControl(buyerLocation.Address.xp?.LocationID),
       Currency: new FormControl(
         buyerLocation.UserGroup.xp.Currency,
         Validators.required
       ),
-      // TODO: remove this workaround when headstart sdk has been updated to include correct type
       BillingNumber: new FormControl(
-        (buyerLocation.Address.xp as any).BillingNumber
+        buyerLocation.Address.xp?.BillingNumber
       ),
       CatalogAssignments: new FormControl(
         undefined,


### PR DESCRIPTION
Applied null-condition operators to address xp properties.
Removed workaround for accessing BillingNumber.

The DefaultBuyerLocation does not include address xp properties; attempting to access this address in the admin threw null reference exceptions. It doesn't appear that these properties are mandatory, therefore the null-conditions should not have any adverse effects.