### PR TITLE
Removed unused labelSingular input from app-storefront-edit reference

### DIFF
--- a/src/UI/Seller/src/app/storefronts/components/storefronts/storefronts-table/storefront-table.component.html
+++ b/src/UI/Seller/src/app/storefronts/components/storefronts/storefronts-table/storefront-table.component.html
@@ -18,7 +18,6 @@
 >
   <app-storefront-edit
     class="resource-edit"
-    [labelSingular]="'Storefront'"
     [resourceInSelection]="updatedResource"
     (updateResource)="updateResource($event)"
   >


### PR DESCRIPTION
Cleaning up unused input, which was throwing an error for attempting to bind unknown property in the console.