### PR TITLE
Improved Swagger documentation

### DIFF
--- a/src/Middleware/src/Headstart.API/Controllers/EnvironmentSeedController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/EnvironmentSeedController.cs
@@ -21,9 +21,11 @@ namespace Headstart.Common.Controllers
         }
 
         /// <summary>
-        /// Call this endpoint when initially seeding a brand new organization
-        /// Check out the readme for more info https://github.com/ordercloud-api/headstart#seeding-ordercloud-data
+        /// Seeds a brand new organization
         /// </summary>
+        /// <remarks>
+        /// Check out the readme for more info https://github.com/ordercloud-api/headstart#seeding-ordercloud-data
+        /// </remarks>
         [HttpPost, Route("seed")]
         public async Task<EnvironmentSeedResponse> Seed([FromBody] EnvironmentSeed seed)
         {

--- a/src/Middleware/src/Headstart.API/Headstart.API.csproj
+++ b/src/Middleware/src/Headstart.API/Headstart.API.csproj
@@ -6,7 +6,12 @@
     <LangVersion>8</LangVersion>
     <ApplicationInsightsResourceId>/subscriptions/736cd8bd-0185-4184-b3dd-8c372c076f3f/resourceGroups/Marketplace/providers/microsoft.insights/components/marketplace-middleware</ApplicationInsightsResourceId>
   </PropertyGroup>
-
+  
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+  
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>

--- a/src/Middleware/src/Headstart.API/Startup.cs
+++ b/src/Middleware/src/Headstart.API/Startup.cs
@@ -42,6 +42,8 @@ using ordercloud.integrations.vertex;
 using Newtonsoft.Json;
 using ordercloud.integrations.taxjar;
 using ordercloud.integrations.library.intefaces;
+using System.IO;
+using System.Linq;
 
 namespace Headstart.API
 {
@@ -220,6 +222,9 @@ namespace Headstart.API
                 {
                     c.SwaggerDoc("v1", new OpenApiInfo { Title = "Headstart Middleware API Documentation", Version = "v1" });
                     c.SchemaFilter<SwaggerExcludeFilter>();
+
+                    List<string> xmlFiles = Directory.GetFiles(AppContext.BaseDirectory, "*.xml", SearchOption.TopDirectoryOnly).ToList();
+                    xmlFiles.ForEach(xmlFile => c.IncludeXmlComments(xmlFile));
                 });
             var serviceProvider = services.BuildServiceProvider();
             services

--- a/src/Middleware/src/Headstart.Common/Headstart.Common.csproj
+++ b/src/Middleware/src/Headstart.Common/Headstart.Common.csproj
@@ -8,6 +8,11 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="Assets\english-translations.json" />
   </ItemGroup>


### PR DESCRIPTION
Configured Swagger to utilise generated XML documentation to improve the Swagger documentation going forward. Notably the summary and remarks tags. See EnvironmentSeed /seed for an example.

If we have any documentation around code quality for contributions, I can add details on how to configure projects to create XML documentation and what tags should be included for controllers and models.