### PR TITLE
Configure swagger docs to respect property casing

### DIFF
--- a/src/Middleware/src/Headstart.API/Controllers/ShipmentController.cs
+++ b/src/Middleware/src/Headstart.API/Controllers/ShipmentController.cs
@@ -39,6 +39,7 @@ namespace Headstart.Common.Controllers
         /// POST Batch Shipment Update
         /// </summary>    
         [HttpPost, Route("batch/uploadshipment"), OrderCloudUserAuth(ApiRole.ShipmentAdmin)]
+        [ApiExplorerSettings(IgnoreApi = true)]
         public async Task<BatchProcessResult> UploadShipments([FromForm] FileUpload fileRequest)
         {
             return  await _command.UploadShipments(fileRequest?.File, UserContext);

--- a/src/Middleware/src/Headstart.API/Headstart.API.csproj
+++ b/src/Middleware/src/Headstart.API/Headstart.API.csproj
@@ -19,6 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
     <PackageReference Include="SendGrid" Version="9.22.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Middleware/src/Headstart.API/Startup.cs
+++ b/src/Middleware/src/Headstart.API/Startup.cs
@@ -225,7 +225,9 @@ namespace Headstart.API
 
                     List<string> xmlFiles = Directory.GetFiles(AppContext.BaseDirectory, "*.xml", SearchOption.TopDirectoryOnly).ToList();
                     xmlFiles.ForEach(xmlFile => c.IncludeXmlComments(xmlFile));
-                });
+                })
+                .AddSwaggerGenNewtonsoftSupport();
+
             var serviceProvider = services.BuildServiceProvider();
             services
                 .AddApplicationInsightsTelemetry(new ApplicationInsightsServiceOptions


### PR DESCRIPTION
@crhistianramirez, as per your comment on #281, I was able to follow this up.

Property casing is now respected, i.e. doesn't force Pascal casing either.
Enums in schemas are now output with their string values, not their numeric value.

Some tech debt introduced, i.e. UploadShipments API needed to be ignored as the BatchProcessResult model could not be parsed correctly and threw an error preventing Swagger documentation from being accessed.