### PR TITLE
Resolved price schedule override error handling

### DIFF
--- a/src/UI/Seller/src/app/products/components/product-pricing/product-pricing.component.ts
+++ b/src/UI/Seller/src/app/products/components/product-pricing/product-pricing.component.ts
@@ -209,7 +209,7 @@ export class ProductPricingComponent {
       this.isSavedOverride = true
       this.isUsingPriceOverride = true
     } catch (ex) {
-      if (ex?.error?.[0].ErrorCode === 'NotFound') {
+      if (ex?.error?.Errors[0].ErrorCode === 'NotFound') {
         this.isSavedOverride = false
         this.isUsingPriceOverride = false
         this.resetOverridePriceSchedules(this.emptyPriceSchedule)


### PR DESCRIPTION
Error notification "Cannot read properties of undefined (rea…ding 'ErrorCode')" was displayeing when a buyer-specific price schedule does not exist. The ErrorCode property could not be read, throwing an exception.
