### PR TITLE
Resolve height calculations for perfect scrollbar containers

### DIFF
--- a/src/UI/Seller/src/app/shared/components/resource-table/resource-table.component.html
+++ b/src/UI/Seller/src/app/shared/components/resource-table/resource-table.component.html
@@ -24,7 +24,7 @@
       (!isMyResource || _currentResourceNamePlural !== 'suppliers') &&
       !excludeFromFilterBar
     "
-    class="row additional-item-edit-resource additional-item-table"
+    class="row additional-item-edit-resource additional-item-table pb-4"
   >
     <div
       *ngIf="parentResourceService && !isMyResource"
@@ -255,7 +255,7 @@
     </div>
   </div>
   <!-- /Filter Bar -->
-  <div class="row mt-4">
+  <div class="row">
     <div class="col-md-12">
       <!-- full table view -->
       <div *ngIf="showFilterBar()">


### PR DESCRIPTION
This one has bothered me since I first opened the seller app. :)

Can be considered a workaround as the true issue lies in the helper getPsHeight() of dom.helper.ts.

Essentially, swapping the resource table margin for the additional item table padding allowed this value to be subtracted from the overall height calculation and corrected the scrollbar container heights.

Also, noting that this change does not impact the visual styling or breakpoint styling in its current state. Overall still more correct if the background colour of additional item table were to be updated.