### PR TITLE
Removed references to TaxCodeCategory and mocked tax categories

### DIFF
--- a/src/Middleware/integrations/ordercloud.integrations.avalara/AvalaraCommand.cs
+++ b/src/Middleware/integrations/ordercloud.integrations.avalara/AvalaraCommand.cs
@@ -77,6 +77,23 @@ namespace ordercloud.integrations.avalara
 			 return result.ToOrderTaxCalculation();
 		}
 
+        private TaxCategorizationResponse CreateMockTaxCategorizationResponseModel()
+        {
+            return new TaxCategorizationResponse()
+            {
+                ProductsShouldHaveTaxCodes = true,
+                Categories = new List<TaxCategorization>()
+                {
+                    new TaxCategorization()
+                    {
+                        Code = "Headstart Tax Code",
+                        Description = "Mock Tax Code for Headstart",
+                        LongDescription = "This is a mock tax categorization"
+                    }
+                }
+            };
+        }
+
         public async Task<OrderTaxCalculation> CommitTransactionAsync(OrderWorksheet orderWorksheet, List<OrderPromotion> promotions)
 		{
 			if (ShouldMockAvalaraResponse()) { return CreateMockTransactionModel(); }
@@ -96,7 +113,9 @@ namespace ordercloud.integrations.avalara
 
 		public async Task<TaxCategorizationResponse> ListTaxCodesAsync(string searchTerm)
 		{
-			var search = TaxCodeMapper.MapSearchString(searchTerm);
+            if (ShouldMockAvalaraResponse()) { return CreateMockTaxCategorizationResponseModel(); }
+
+            var search = TaxCodeMapper.MapSearchString(searchTerm);
 			var avataxCodes = await _avaTax.ListTaxCodesAsync(search, null, null, null);
 			var codeList = TaxCodeMapper.MapTaxCodes(avataxCodes);
 			return new TaxCategorizationResponse() { Categories = codeList, ProductsShouldHaveTaxCodes = true };

--- a/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.html
+++ b/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.html
@@ -523,7 +523,7 @@
                   [productForm]="productForm"
                   [superHSProductEditable]="_superHSProductEditable"
                   [taxCodes]="taxCodes?.Categories"
-                  [isRequired]="isRequired('TaxCodeCategory')"
+                  [isRequired]="isRequired('TaxCode')"
                   [isCreatingNew]="isCreatingNew"
                   (handleTaxCodeSelection)="
                     handleTaxCodeSelection($event.target.value)

--- a/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.ts
+++ b/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.ts
@@ -339,10 +339,6 @@ export class ProductEditComponent implements OnInit, OnDestroy {
           OrderCanExceed: new FormControl(
             _get(superHSProduct.Product, 'Inventory.OrderCanExceed')
           ),
-          TaxCodeCategory: new FormControl(
-            _get(superHSProduct.Product, 'xp.Tax.Category', null),
-            Validators.required
-          ),
           TaxCode: new FormControl(
             _get(superHSProduct.Product, 'xp.Tax.Code', null),
             Validators.required
@@ -468,7 +464,6 @@ export class ProductEditComponent implements OnInit, OnDestroy {
 
   setNonRequiredFields(): void {
     const optionalFieldsArray = [
-      'TaxCodeCategory',
       'TaxCode',
       'ShipWeight',
       'ShipFromAddressID',
@@ -509,7 +504,6 @@ export class ProductEditComponent implements OnInit, OnDestroy {
       this.isShippingValid() &&
       this.unitOfMeasureValid() &&
       this.productForm.controls.Name.valid &&
-      this.productForm.controls.TaxCodeCategory.valid &&
       this.productForm.controls.TaxCode.valid
     )
   }


### PR DESCRIPTION
It looks like as part of #270 there were several issues that resulted including removed mocked response for tax categories and the tax piece in the product details form still contained references to the TaxCodeCategory, which was causing the form to always be invalid.

Mocked response only added to Avalara for now, but will look to handle mocked responses better as part of the tax provider refactor piece.