### PR TITLE
Resolve console errors over unknown component property 'isAssigned'

### DIFF
--- a/src/UI/Seller/src/app/shared/components/buyer-visibility/product-visibility-assignments/product-visibility-assignments.component.html
+++ b/src/UI/Seller/src/app/shared/components/buyer-visibility/product-visibility-assignments/product-visibility-assignments.component.html
@@ -17,7 +17,6 @@
           <buyer-visibility-configuration-component
             [product]="product"
             [buyer]="buyer"
-            [isAssigned]="isAssigned(buyer)"
           ></buyer-visibility-configuration-component>
         </li>
       </ul>


### PR DESCRIPTION
Removed unknown property 'isAssigned' as is not an input object of buyer-visibility-configuration-component. Resolves console error.

Assuming this is a hangover from initial solution conversion/clean up.