### PR TITLE
Resolve console errors over unknown component property 'isEditing'

### DIFF
--- a/src/UI/Seller/src/app/shared/components/buyer-visibility/buyer-visibility-configuration/buyer-visibility-configuration.component.html
+++ b/src/UI/Seller/src/app/shared/components/buyer-visibility/buyer-visibility-configuration/buyer-visibility-configuration.component.html
@@ -111,7 +111,6 @@
     [productID]="_product.ID"
     [assignedCategoriesStatic]="assignedCategoriesEditable"
     [catalogID]="_buyer.ID"
-    [isEditing]="isEditing"
     (assignmentsUpdated)="updateCategoryAssignments($event)"
   ></product-category-assignment>
   <div class="mt-3 d-flex justify-content-end">


### PR DESCRIPTION
Removed unknown property 'isEditing' as is not an input object of product-category-assignment. Resolves console error.

Assuming this is a hangover from initial solution conversion/clean up.