### PR TITLE
Resolved translatation issue for shipping rates

### DIFF
--- a/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.html
+++ b/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.html
@@ -784,8 +784,8 @@
               >
                 {{ getDateRangeDisplay() }}
               </li>
-              <li *ngIf="_promotionEditable?.xp?.MaxShipCost" translate>
-                ADMIN.PROMOTIONS.APPLIES_TO_RATES
+              <li *ngIf="_promotionEditable?.xp?.MaxShipCost">
+                {{ 'ADMIN.PROMOTIONS.APPLIES_TO_RATES' | translate }}
                 {{ _promotionEditable?.xp?.MaxShipCost | currency }}
               </li>
               <li>{{ getEligibilityDisplay() }}</li>


### PR DESCRIPTION
The translate attribute cannot resolve keys with additional string concatenation applied within html element unless the additional text is nested in another html element.