### PR TITLE
Fixed Product Description Updates

### DIFF
--- a/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.html
+++ b/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.html
@@ -83,7 +83,7 @@
                     id="Percentage"
                     value="Percentage"
                     formControlName="Type"
-                    (change)="handleUpdatePromo($event, 'xp.Type')"
+                    (change)="handleUpdatePromoType($event, 'xp.Type')"
                     [checked]="promoTypeCheck('Percentage')"
                   />
                   <label class="form-check-label" for="Percentage" translate>
@@ -98,7 +98,7 @@
                     id="FixedAmount"
                     value="FixedAmount"
                     formControlName="Type"
-                    (change)="handleUpdatePromo($event, 'xp.Type')"
+                    (change)="handleUpdatePromoType($event, 'xp.Type')"
                     [checked]="promoTypeCheck('FixedAmount')"
                   />
                   <label class="form-check-label" for="FixedAmount" translate>
@@ -113,7 +113,7 @@
                     id="FreeShipping"
                     value="FreeShipping"
                     formControlName="Type"
-                    (change)="handleUpdatePromo($event, 'xp.Type')"
+                    (change)="handleUpdatePromoType($event, 'xp.Type')"
                     [checked]="promoTypeCheck('FreeShipping')"
                   />
                   <label class="form-check-label" for="FreeShipping" translate>
@@ -150,7 +150,7 @@
                   class="form-control"
                   formControlName="Value"
                   min="0"
-                  (input)="handleUpdatePromo($event, 'xp.Value', 'number')"
+                  (input)="handleUpdatePromoType($event, 'xp.Value', 'number')"
                   id="{{ _promotionEditable?.xp?.Type }}"
                 />
                 <div
@@ -775,7 +775,7 @@
             "
           >
             <ul>
-              <li>{{ getValueDisplay() }}</li>
+              <li>{{ _promotionEditable?.Description }}</li>
               <li
                 *ngIf="
                   _promotionEditable?.StartDate &&

--- a/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.ts
+++ b/src/UI/Seller/src/app/promotions/components/promotion-edit/promotion-edit.component.ts
@@ -292,6 +292,11 @@ export class PromotionEditComponent implements OnInit, OnChanges {
     this.resourceForm.controls.Code.setValue(randomCode)
   }
 
+  handleUpdatePromoType(event: any, field: string, typeOfValue?: string): void {
+    this.handleUpdatePromo(event, field, typeOfValue);
+    this.updateDescription();
+  }
+
   handleUpdatePromo(event: any, field: string, typeOfValue?: string): void {
     if (
       field === 'xp.AppliesTo' &&
@@ -345,7 +350,7 @@ export class PromotionEditComponent implements OnInit, OnChanges {
     return eligibility === this._promotionEditable?.xp?.AppliesTo
   }
 
-  getValueDisplay(): string {
+  updateDescription(): void {
     const safeXp = this._promotionEditable?.xp
     let valueString = ''
     switch (safeXp?.AppliesTo) {
@@ -372,7 +377,6 @@ export class PromotionEditComponent implements OnInit, OnChanges {
       { target: { value: valueString.trim() } },
       'Description'
     )
-    return valueString.trim()
   }
 
   arrangeValueString(safeXp: PromotionXp, valueString: string): string {


### PR DESCRIPTION
Having the getValueDisplay() in the template was only being called when the surrounding ngif condition was evaluated to true (This also flags other issues with being able to create incomplete promotions).

When the ngif condition did evaluate, as there are 3 other ngif conditions within this included markup, this causes the getValueDisplay() to evaluate each time, so this change also optimises the evaluation of the description only when required.