### PR TITLE
fix bug where can't save product because tax category is missing

### DIFF
--- a/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.html
+++ b/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.html
@@ -4,7 +4,13 @@
       productInReviewNotifications?.length > 0 &&
       userContext?.UserType === 'SUPPLIER'
     "
-    class="alert alert-warning d-flex justify-content-start align-items-center set-to-top"
+    class="
+      alert alert-warning
+      d-flex
+      justify-content-start
+      align-items-center
+      set-to-top
+    "
   >
     <fa-icon [icon]="faExclamationCircle" class="mr-3"></fa-icon>
     <p class="mb-0">
@@ -20,7 +26,13 @@
       class="alert alert-warning set-to-top"
     >
       <div
-        class="pb-3 border-bottom d-flex justify-content-between align-items-center"
+        class="
+          pb-3
+          border-bottom
+          d-flex
+          justify-content-between
+          align-items-center
+        "
       >
         <div class="d-flex justify-content-start align-items-center">
           <fa-icon [icon]="faExclamationCircle" class="mr-3"></fa-icon>
@@ -523,7 +535,6 @@
                   [productForm]="productForm"
                   [superHSProductEditable]="_superHSProductEditable"
                   [taxCodes]="taxCodes?.Categories"
-                  [isRequired]="isRequired('TaxCode')"
                   [isCreatingNew]="isCreatingNew"
                   (handleTaxCodeSelection)="
                     handleTaxCodeSelection($event.target.value)
@@ -534,7 +545,8 @@
                       { target: { value: $event } },
                       'Product.xp.IsResale'
                     )
-                  "                >
+                  "
+                >
                 </product-tax-code-select-component>
                 <!-- /Tax Categorization -->
                 <!-- Shipping Information -->
@@ -816,13 +828,26 @@
               <!-- Product Preview -->
               <div class="col-md-4">
                 <div
-                  class="card py-2 px-3 bg-white sticky-top product-preview-card"
+                  class="
+                    card
+                    py-2
+                    px-3
+                    bg-white
+                    sticky-top
+                    product-preview-card
+                  "
                 >
                   <p class="text-center font-weight-bold" translate>
                     ADMIN.PRODUCT_EDIT.PRODUCT_PREVIEW
                   </p>
                   <div
-                    class="card product-preview w-100 border-hover cursor-pointer"
+                    class="
+                      card
+                      product-preview
+                      w-100
+                      border-hover
+                      cursor-pointer
+                    "
                   >
                     <div class="ribbon ribbon-top-right bg-light">
                       <fa-icon
@@ -837,7 +862,13 @@
                         [alt]="_superHSProductEditable?.Product?.Name"
                       />
                       <div
-                        class="card-body d-flex flex-column justify-content-between bg-light"
+                        class="
+                          card-body
+                          d-flex
+                          flex-column
+                          justify-content-between
+                          bg-light
+                        "
                       >
                         <h5
                           class="card-title"
@@ -857,7 +888,12 @@
                           }}
                         </p>
                         <div
-                          class="d-flex flex-wrap justify-content-between align-items-center"
+                          class="
+                            d-flex
+                            flex-wrap
+                            justify-content-between
+                            align-items-center
+                          "
                         >
                           <p class="card-text mb-0">
                             {{
@@ -1132,7 +1168,12 @@
               <div class="col-md-7">
                 <!--droped image preview-->
                 <div
-                  class="d-flex justify-content-start align-items-center flex-wrap"
+                  class="
+                    d-flex
+                    justify-content-start
+                    align-items-center
+                    flex-wrap
+                  "
                 >
                   <div
                     *ngFor="let image of images; let i = index"
@@ -1147,7 +1188,13 @@
                       />
                       <span
                         *ngIf="i === 0"
-                        class="badge badge-primary primary-badge position-absolute mt-1 ml-1"
+                        class="
+                          badge badge-primary
+                          primary-badge
+                          position-absolute
+                          mt-1
+                          ml-1
+                        "
                         translate
                       >
                         ADMIN.PRODUCT_EDIT.PRIMARY
@@ -1245,7 +1292,12 @@
               <div class="col-md-7">
                 <!--droped doc preview-->
                 <div
-                  class="d-flex justify-content-start align-items-center flex-wrap"
+                  class="
+                    d-flex
+                    justify-content-start
+                    align-items-center
+                    flex-wrap
+                  "
                 >
                   <div *ngIf="!readonly" class="input-group mb-3">
                     <input
@@ -1366,7 +1418,13 @@
   </form>
   <!-- TODO: 2/2 Abstract into component to be used anywhere using inputs and outputs -->
   <div
-    class="d-flex justify-content-between align-items-center py-2 product-edit-actions"
+    class="
+      d-flex
+      justify-content-between
+      align-items-center
+      py-2
+      product-edit-actions
+    "
   >
     <delete-confirm-modal-component
       *ngIf="!isCreatingNew"

--- a/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.ts
+++ b/src/UI/Seller/src/app/products/components/product-edit/product-edit.component.ts
@@ -121,7 +121,6 @@ export class ProductEditComponent implements OnInit, OnDestroy {
   sellerCurrency: SupportedRates
   _exchangeRates: SupportedRates[]
   areChanges = false
-  taxCodeCategorySelected = false
   taxCodes: TaxCategorizationResponse
   productType: ProductXp['ProductType']
   shippingAddress: any
@@ -159,16 +158,16 @@ export class ProductEditComponent implements OnInit, OnDestroy {
     private toastrService: ToastrService,
     private assetService: AssetService,
     private translate: TranslateService
-  ) { }
+  ) {}
 
   async ngOnInit(): Promise<void> {
     // TODO: Eventually move to a resolve so that they are there before the component instantiates.
     this.isCreatingNew = this.productService.checkIfCreatingNew()
     this.getAddresses()
-    var getTaxCategoriesPromise = this.initTaxCategorization();
+    const getTaxCategoriesPromise = this.initTaxCategorization()
     this.userContext = await this.currentUserService.getUserContext()
-    await this.getAvailableProductTypes();
-    await getTaxCategoriesPromise;
+    await this.getAvailableProductTypes()
+    await getTaxCategoriesPromise
     this.setProductEditTab()
   }
 
@@ -229,13 +228,11 @@ export class ProductEditComponent implements OnInit, OnDestroy {
         Qty: null,
       }
     }
-   
-    this.taxCodes = await HeadStartSDK.TaxCategories.ListTaxCategories();
-   
+
+    this.taxCodes = await HeadStartSDK.TaxCategories.ListTaxCategories()
+
     this.staticContent = this._superHSProductEditable.Product?.xp.Documents
     this.images = this._superHSProductEditable.Product?.xp?.Images
-    this.taxCodeCategorySelected =
-      this._superHSProductEditable.Product?.xp?.Tax?.Code !== null
     this.productType = this._superHSProductEditable.Product?.xp?.ProductType
     this.createProductForm(this._superHSProductEditable)
     if (
@@ -363,7 +360,7 @@ export class ProductEditComponent implements OnInit, OnDestroy {
           ),
           FreeShippingMessage: new FormControl(
             _get(superHSProduct.Product, 'xp.FreeShippingMessage') ||
-            'Free Shipping'
+              'Free Shipping'
           ),
         },
         { validators: ValidateMinMax }
@@ -589,7 +586,7 @@ export class ProductEditComponent implements OnInit, OnDestroy {
       this.dataIsSaving = false
     } catch (ex) {
       this.dataIsSaving = false
-      const message = ex?.response?.data?.Data as string;
+      const message = ex?.response?.data?.Data as string
       if (message) {
         this.toastrService.error(message, 'Error', { onActivateTick: true })
       }
@@ -607,7 +604,7 @@ export class ProductEditComponent implements OnInit, OnDestroy {
   productWasModified(): boolean {
     return (
       JSON.stringify(this._superHSProductEditable) !==
-      JSON.stringify(this._superHSProductStatic) ||
+        JSON.stringify(this._superHSProductStatic) ||
       this.imageFiles.length > 0 ||
       this.staticContentFiles.length > 0
     )
@@ -636,10 +633,11 @@ export class ProductEditComponent implements OnInit, OnDestroy {
   updateProductResource(productUpdate: any): void {
     const resourceToUpdate =
       this._superHSProductEditable || this.productService.emptyResource
-    this._superHSProductEditable = this.productService.getUpdatedEditableResource(
-      productUpdate,
-      resourceToUpdate
-    )
+    this._superHSProductEditable =
+      this.productService.getUpdatedEditableResource(
+        productUpdate,
+        resourceToUpdate
+      )
     this.checkForChanges()
   }
 
@@ -657,8 +655,8 @@ export class ProductEditComponent implements OnInit, OnDestroy {
       value: productFields.includes(field)
         ? event.target.checked
         : typeOfValue === 'number'
-          ? Number(event.target.value)
-          : event.target.value,
+        ? Number(event.target.value)
+        : event.target.value,
     }
 
     if (field === 'PriceSchedule.MaxQuantity' && productUpdate.value === 0) {
@@ -692,7 +690,7 @@ export class ProductEditComponent implements OnInit, OnDestroy {
   checkForChanges(): void {
     this.areChanges =
       JSON.stringify(this._superHSProductEditable) !==
-      JSON.stringify(this._superHSProductStatic) ||
+        JSON.stringify(this._superHSProductStatic) ||
       this.imageFiles?.length > 0 ||
       this.staticContentFiles?.length > 0
   }
@@ -735,11 +733,12 @@ export class ProductEditComponent implements OnInit, OnDestroy {
   }
 
   async removeFile(file: DocumentAsset, assetType: AssetType): Promise<void> {
-    this._superHSProductStatic.Product = await this.assetService.deleteAssetUpdateProduct(
-      this._superHSProductEditable.Product,
-      file.Url,
-      assetType
-    )
+    this._superHSProductStatic.Product =
+      await this.assetService.deleteAssetUpdateProduct(
+        this._superHSProductEditable.Product,
+        file.Url,
+        assetType
+      )
     this.updateList.emit(this._superHSProductStatic.Product as Product)
     void this.refreshProductData(this._superHSProductStatic)
   }
@@ -787,13 +786,14 @@ export class ProductEditComponent implements OnInit, OnDestroy {
       this._superHSProductEditable.Product.xp.Tax = {
         Code: '',
         Description: '',
-        LongDescription: ''
+        LongDescription: '',
       }
     }
-    this.taxCodes = await HeadStartSDK.TaxCategories.ListTaxCategories();
+    this.taxCodes = await HeadStartSDK.TaxCategories.ListTaxCategories()
   }
 
   handleTaxCodeSelection(event: TaxCategorization): void {
+    debugger
     const codeUpdate = { target: { value: event.Code } }
     const descriptionUpdate = { target: { value: event.Description } }
     this.productForm.controls.TaxCode.setValue(event.Code)
@@ -802,7 +802,9 @@ export class ProductEditComponent implements OnInit, OnDestroy {
   }
 
   async searchTaxCodes(searchTerm: string): Promise<void> {
-    this.taxCodes = await HeadStartSDK.TaxCategories.ListTaxCategories(searchTerm ?? "");
+    this.taxCodes = await HeadStartSDK.TaxCategories.ListTaxCategories(
+      searchTerm ?? ''
+    )
   }
 
   getSaveBtnText(): string {
@@ -824,10 +826,8 @@ export class ProductEditComponent implements OnInit, OnDestroy {
     superHSProduct.PriceSchedule.Name = `Default_HS_Buyer${superHSProduct.Product.Name}`
     // Slice Price Schedule if more than 100 characters after the pre-pended 'Default_HS_Buyer'.
     if (superHSProduct.PriceSchedule.Name.length > 100) {
-      superHSProduct.PriceSchedule.Name = superHSProduct.PriceSchedule.Name.slice(
-        0,
-        100
-      )
+      superHSProduct.PriceSchedule.Name =
+        superHSProduct.PriceSchedule.Name.slice(0, 100)
     }
     if (superHSProduct.Product.xp.Tax.Code === null)
       superHSProduct.Product.xp.Tax = null
@@ -865,10 +865,8 @@ export class ProductEditComponent implements OnInit, OnDestroy {
       superHSProduct.PriceSchedule.Name = `Default_HS_Buyer${superHSProduct.Product.Name}`
       // Slice Price Schedule if more than 100 characters after the pre-pended 'Default_HS_Buyer'.
       if (superHSProduct.PriceSchedule.Name.length > 100) {
-        superHSProduct.PriceSchedule.Name = superHSProduct.PriceSchedule.Name.slice(
-          0,
-          100
-        )
+        superHSProduct.PriceSchedule.Name =
+          superHSProduct.PriceSchedule.Name.slice(0, 100)
       }
     }
     if (!superHSProduct.Product.xp) {


### PR DESCRIPTION
tax category was removed in order to streamline with the format defined by other tax providers however the form validation was still requiring it and preventing user to save product.