### PR TITLE
Changed docker setup to use Cosmos Emulator Container

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,13 +6,10 @@ SELLER_ID=""
 SELLER_CLIENT_ID=""
 BUYER_CLIENT_ID=""
 
-CosmosSettings_EndpointUri=""
-
 EasyPostSettings_APIKey="" 
 
 OrderCloudSettings_MiddlewareClientID=""
 OrderCloudSettings_MiddlewareClientSecret=""
-OrderCloudSettings_WebhookHashKey=""
 
 SmartyStreetSettings_AuthID=""
 SmartyStreetSettings_AuthToken=""
@@ -23,6 +20,9 @@ SmartyStreetSettings_AuthToken=""
 
 REGISTRY=
 VERSION=local
+
+AZUREITE_TAG=3.15.0
+COSMOS_TAG=latest
 
 BUYER_HOST=buyer.headstart.localhost
 SELLER_HOST=seller.headstart.localhost
@@ -74,6 +74,7 @@ FlurlSettings_TimeoutInSeconds="40"
 
 OrderCloudSettings_ApiUrl="https://sandboxapi.ordercloud.io"
 OrderCloudSettings_IncrementorPrefix="DB_TEST"
+OrderCloudSettings_WebhookHashKey=""
 
 SendGridSettings_ApiKey="12234"
 SendgridSettings_FromEmail=""

--- a/.env.template
+++ b/.env.template
@@ -6,9 +6,7 @@ SELLER_ID=""
 SELLER_CLIENT_ID=""
 BUYER_CLIENT_ID=""
 
-CosmosSettings_DatabaseName=""
 CosmosSettings_EndpointUri=""
-CosmosSettings_PrimaryKey=""
 
 EasyPostSettings_APIKey="" 
 
@@ -60,6 +58,8 @@ CardConnectSettings_UsdMerchantID=""
 
 CosmosSettings_EnableTcpConnectionEndpointRediscovery="false"
 CosmosSettings_RequestTimeoutInSeconds="15"
+CosmosSettings_DatabaseName="headstart"
+CosmosSettings_PrimaryKey="C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
 
 EasyPostSettings_FreeShippingTransitDays="3"
 EasyPostSettings_NoRatesFallbackCost="20"

--- a/README.md
+++ b/README.md
@@ -283,24 +283,32 @@ This project follows the [build once, deploy many](https://earlyandoften.wordpre
 
 ## Docker
 
-You can run the project using Docker, sample docker-compose.yml file includes Buyer/Seller/Middleware as well as emulated Azure Storage via [Azurite](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio). Note you will currently still need a Cosmos DB instance hosted in Azure.
+You can run the project using Docker, sample docker-compose.yml file includes Buyer/Seller/Middleware as well as emulated Azure Storage via [Azurite](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio), and Cosmos DB via the [Cosmos DB Emulator](https://docs.microsoft.com/en-us/azure/cosmos-db/linux-emulator).
 
-1. Create a Cosmos DB instance in Azure & make a note of your chosen `databasename`, and the generated `endpointUri` and `PrimaryKey`.
-2. Make sure to [switch daemon to Linux containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers)
-3. Copy `.env.template` file to `.env`
-4. Open `.env` file and populate the following variables in the `REQUIRED ENVIRONMENT VARIABLES` section:
-    - CosmosSettings_DatabaseName
-    - CosmosSettings_EndpointUri
-    - CosmosSettings_PrimaryKey
-5. Add the following records to your Hosts file
+1. Make sure to [switch daemon to Linux containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers)
+2. Copy `.env.template` file to `.env`
+3. Add the following records to your Hosts file
     - 127.0.0.1 buyer.headstart.localhost
     - 127.0.0.1 seller.headstart.localhost
     - 127.0.0.1 api.headstart.localhost
-6. From the project directory, start up your application by running `docker-compose up -d`
-7. Follow the steps to seed the initial data values listed in the [Seeding OrderCloud Data](https://github.com/ordercloud-api/headstart#seeding-ordercloud-data) section above.
-8.  Open `.env` file and populate the rest of the variables in the `REQUIRED ENVIRONMENT VARIABLES` section, using the output values from the `/seed` command response.
-9. Restart your docker containers to make use of the new env vars by running `docker-compose restart`
-10. Follow the steps in the [Validating Setup](https://github.com/ordercloud-api/headstart#validating-setup) section above to walk through generating some sample data and testing each of the application instances.
+4. From the project directory, start up your application by running `docker-compose up -d`
+    - Note the `Middleware` container may take longer to start as it depends on the Cosmos emulator being healthy.
+5. Follow the steps to seed the initial data values listed in the [Seeding OrderCloud Data](https://github.com/ordercloud-api/headstart#seeding-ordercloud-data) section above.
+6. Open `.env` file and populate the rest of the variables in the `REQUIRED ENVIRONMENT VARIABLES` section:
+    - The following values comes from from the `/seed` command response executed in previous step
+        - SELLER_CLIENT_ID
+        - BUYER_CLIENT_ID
+        - OrderCloudSettings_MiddlewareClientID
+        - OrderCloudSettings_MiddlewareClientSecret
+        - SELLER_ID (This should be set to the `MarketplaceID`)
+    - The following values need to be obtained by create accounts with EasyPost & SmartyStreets
+        - EasyPostSettings_APIKey 
+        - SmartyStreetSettings_AuthID
+        - SmartyStreetSettings_AuthToken
+    
+7. Restart your docker containers to make use of the new env vars by running `docker-compose down` followed by `docker-compose up -d`.
+    - Note you can't run a `docker-compose restart` here as if the containers are already running then the Middleware app will restart before Cosmos is healthy.
+8. Follow the steps in the [Validating Setup](https://github.com/ordercloud-api/headstart#validating-setup) section above to walk through generating some sample data and testing each of the application instances.
 
 ## Git Flow
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,9 @@ services:
       ZohoSettings_ClientSecret: "${ZohoSettings_ClientSecret}"
       ZohoSettings_OrgID: "${ZohoSettings_OrgID}"
       ZohoSettings_PerformOrderSubmitTasks: "${ZohoSettings_PerformOrderSubmitTasks}"
+    depends_on:
+      cosmos:
+        condition: service_healthy
     networks:
       headstart:
         aliases:
@@ -169,7 +172,7 @@ services:
 
   storage:
   # https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite#install-and-run-the-azurite-docker-image
-    image: mcr.microsoft.com/azure-storage/azurite
+    image: mcr.microsoft.com/azure-storage/azurite:${AZUREITE_TAG}
     volumes:
       - ./docker/data/storage:/data
     environment:
@@ -179,6 +182,29 @@ services:
     ports:
       - 10000:10000
       - 10001:10001
+    networks:
+      headstart:
+
+  cosmos:
+    image: ${REGISTRY}headstart-cosmos:${VERSION}-linux
+    mem_limit: 3g
+    cpu_count: 2
+    build:
+      context: .
+      dockerfile: docker/build/cosmos/Dockerfile
+      args:
+        BASE_IMAGE: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:${COSMOS_TAG}
+    environment:
+      AZURE_COSMOS_EMULATOR_PARTITION_COUNT: 10
+      AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE: "true"
+    ports:
+      - 8081:8081
+      - 10251:10251
+      - 10252:10252
+      - 10253:10253
+      - 10254:10254
+    healthcheck:
+       test: ["CMD-SHELL", "curl -f -k https://localhost:8081/_explorer/emulator.pem || exit 1"]
     networks:
       headstart:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,6 @@ services:
 
       CosmosSettings_DatabaseName: "${CosmosSettings_DatabaseName}"
       CosmosSettings_EnableTcpConnectionEndpointRediscovery: "${CosmosSettings_EnableTcpConnectionEndpointRediscovery}"
-      CosmosSettings_EndpointUri: "${CosmosSettings_EndpointUri}"
       CosmosSettings_PrimaryKey: "${CosmosSettings_PrimaryKey}"
       CosmosSettings_RequestTimeoutInSeconds: "${CosmosSettings_RequestTimeoutInSeconds}"
 
@@ -171,7 +170,6 @@ services:
           - "${BUYER_HOST}"
 
   storage:
-  # https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite#install-and-run-the-azurite-docker-image
     image: mcr.microsoft.com/azure-storage/azurite:${AZUREITE_TAG}
     volumes:
       - ./docker/data/storage:/data

--- a/docker/build/cosmos/Dockerfile
+++ b/docker/build/cosmos/Dockerfile
@@ -1,0 +1,6 @@
+# escape=`
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as build
+
+RUN apt install -y curl

--- a/docker/build/middleware/Dockerfile
+++ b/docker/build/middleware/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --update nodejs npm
 
 RUN npm install -g json
 
-RUN apk add --no-cache --upgrade bash
+RUN apk add --no-cache --upgrade bash curl dos2unix
 
 WORKDIR /app
 
@@ -33,7 +33,7 @@ COPY docs/Reference.md ./reference.md
 
 COPY docker/build/middleware/* ./
 
-RUN apk add dos2unix && dos2unix /app/entrypoint.sh
+RUN dos2unix /app/entrypoint.sh
 
 EXPOSE 80
 

--- a/docker/build/middleware/entrypoint.sh
+++ b/docker/build/middleware/entrypoint.sh
@@ -1,3 +1,13 @@
+echo "Getting Cosmos IP Address"
+CosmosContainerIpAddress=`ping cosmos -c1 | head -1 | grep -Eo '[0-9.]{4,}'`
+CosmosEndpointURI=`echo "https://$CosmosContainerIpAddress:8081"`
+
+echo "Installing the cosmos emulator cert locally"
+curl -k $CosmosEndpointURI/_explorer/emulator.pem > ~/emulatorcert.crt
+cp ~/emulatorcert.crt /usr/local/share/ca-certificates/
+update-ca-certificates
+
+echo "Persisting settings to appSettings.json"
 touch appSettings.json
 echo '{}' > appSettings.json
 
@@ -32,7 +42,7 @@ json -I -f appSettings.json \
 json -I -f appSettings.json \
       -e "this['CosmosSettings:DatabaseName']='$CosmosSettings_DatabaseName'" \
       -e "this['CosmosSettings:EnableTcpConnectionEndpointRediscovery']='$CosmosSettings_EnableTcpConnectionEndpointRediscovery'" \
-      -e "this['CosmosSettings:EndpointUri']='$CosmosSettings_EndpointUri'" \
+      -e "this['CosmosSettings:EndpointUri']='$CosmosEndpointURI'" \
       -e "this['CosmosSettings:PrimaryKey']='$CosmosSettings_PrimaryKey'" \
       -e "this['CosmosSettings:RequestTimeoutInSeconds']='$CosmosSettings_RequestTimeoutInSeconds'"
 
@@ -90,4 +100,5 @@ json -I -f appSettings.json \
       -e "this['ZohoSettings:OrgID']='$ZohoSettings_OrgID'" \
       -e "this['ZohoSettings:PerformOrderSubmitTasks']='$ZohoSettings_PerformOrderSubmitTasks'"
 
+echo "Run Middleware"
 dotnet Headstart.API.dll


### PR DESCRIPTION
This commit updates the Docker setup to now use a container based instance of the Cosmos Emulator instead of requiring the developer to standup a full Cosmos DB instance in Azure. It is now possible to run all of the headstart application elements on your local development machine, no azure assets are required anymore.

README Docker setup setup steps have also been updated to reflect this change.