### PR TITLE
HDS-326 - Override outgoing unit price on quote lines

### DIFF
--- a/src/UI/Seller/src/app/orders/components/line-item-table/line-item-table.component.ts
+++ b/src/UI/Seller/src/app/orders/components/line-item-table/line-item-table.component.ts
@@ -24,8 +24,6 @@ export class LineItemTableComponent {
     void this.setSupplierOrders(value)
   }
   @Input() orderDirection: 'Incoming' | 'Outgoing'
-  @Input() buyerLineItems: HSLineItem[]
-  @Input() isSellerUser = false
   @Output() orderChange = new EventEmitter()
   isSaving = false
 
@@ -107,16 +105,5 @@ export class LineItemTableComponent {
 
   getImageUrl(lineItemID: string): string {
     return getPrimaryLineItemImage(lineItemID, this._lineItems)
-  }
-
-  getLineTotal(lineItem: HSLineItem): number {
-    return lineItem?.Product?.xp?.ProductType === 'Quote' && !this.isSellerUser
-      ? this.getQuotePricing(lineItem)
-      : lineItem?.LineTotal
-  }
-
-  getQuotePricing(lineItem: HSLineItem): number {
-    return this.buyerLineItems?.find((line) => line.ID === lineItem.ID)
-      ?.LineTotal
   }
 }

--- a/src/UI/Seller/src/app/orders/components/order-details/order-details.component.html
+++ b/src/UI/Seller/src/app/orders/components/order-details/order-details.component.html
@@ -298,8 +298,6 @@
       [orderDirection]="orderDirection"
       (orderChange)="refreshOrder()"
       [order]="_order"
-      [buyerLineItems]="_buyerLineItems"
-      [isSellerUser]="isSellerUser"
     >
     </app-line-item-table>
     <div class="row">
@@ -313,7 +311,7 @@
             <div class="d-flex justify-content-between align-items-center mb-1">
               <p class="font-weight-bolder mb-0 text-muted">Subtotal</p>
               <p class="mb-0">
-                {{ getOrderSubtotal(_order) | currency: _order?.xp?.Currency }}
+                {{ _order?.Subtotal | currency: _order?.xp?.Currency }}
               </p>
             </div>
             <div class="d-flex justify-content-between align-items-center mb-1">
@@ -345,7 +343,7 @@
             <p class="font-weight-bolder mb-0">Total</p>
             <p class="font-weight-bolder mb-0">
               {{ _order?.xp?.Currency
-              }}{{ getOrderTotal(_order) | currency: _order?.xp?.Currency }}
+              }}{{ _order?.Total | currency: _order?.xp?.Currency }}
             </p>
           </div>
           <div

--- a/src/UI/Seller/src/app/orders/components/order-details/order-details.component.ts
+++ b/src/UI/Seller/src/app/orders/components/order-details/order-details.component.ts
@@ -71,7 +71,6 @@ export class OrderDetailsComponent {
   _buyerOrder: Order = {}
   _buyerQuoteAddress: Address = null
   _supplierOrder: Order = {}
-  _buyerLineItems: HSLineItem[] = []
   _lineItems: HSLineItem[] = []
   _payments: Payment[] = []
   images: any[] = []
@@ -265,7 +264,6 @@ export class OrderDetailsComponent {
         this._order.xp?.OrderType
       )
       this._buyerOrder = orderData.BuyerOrder.Order
-      this._buyerLineItems = orderData.BuyerOrder.LineItems
       this._supplierOrder = orderData.SupplierOrder.Order
       this._lineItems = orderData.SupplierOrder.LineItems
     } else {
@@ -365,24 +363,5 @@ export class OrderDetailsComponent {
 
   buildOrderDetailsRoute(rma: RMA): string {
     return `/rmas/${rma.RMANumber}`
-  }
-
-  getOrderSubtotal(order: HSOrder): number {
-    return this._buyerLineItems.some(
-      (li) => li.Product?.xp?.ProductType === 'Quote'
-    )
-      ? this._buyerOrder?.Subtotal
-      : order?.Subtotal
-  }
-
-  getOrderTotal(order: HSOrder): number {
-    if (
-      !this.isSellerUser &&
-      this._buyerLineItems.some((li) => li.Product?.xp?.ProductType === 'Quote')
-    ) {
-      return this._buyerOrder?.Subtotal
-    } else {
-      return order?.Total
-    }
   }
 }


### PR DESCRIPTION
<!-- Note: Remember to transition the issue to complete *after* you have verified the changes are deployed -->

## Description
1) Overriding the unit price on outgoing line items that are quotes so that they equal the sales order line unit pricing.

For Reference: [HDS-326](https://four51.atlassian.net/browse/HDS-326) <!--  Ignore if PR from external developer -->

- [x] I have updated the acceptance criteria on the task so that it can be tested
