### PR TITLE
fix: Add reference to faCheckCircle on checkout-payment component

### DIFF
--- a/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
+++ b/src/UI/Buyer/src/app/components/checkout/checkout-payment/checkout-payment.component.ts
@@ -13,6 +13,7 @@ import { SelectedCreditCard } from 'src/app/models/credit-card.types'
 import { AcceptedPaymentTypes } from 'src/app/models/checkout.types'
 import { OrderSummaryMeta } from 'src/app/models/order.types'
 import { AppConfig } from 'src/app/models/environment.types'
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons'
 
 @Component({
   templateUrl: './checkout-payment.component.html',
@@ -32,11 +33,11 @@ export class OCMCheckoutPayment implements OnInit {
   _acceptedPaymentMethods: string[]
   selectedPaymentMethod: AcceptedPaymentTypes
   POTermsAccepted: boolean
-
+  faCheckCircle = faCheckCircle
   constructor(
     private context: ShopperContextService,
     private appConfig: AppConfig
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this._orderCurrency = this.context.currentUser.get().Currency


### PR DESCRIPTION
This is a fix for issue #350 - Error thrown when pressing Accept button in Checkout Component
The error is due to a missing reference to the icon that is supposed to be shown.
Here is a GIF demonstrating the fix:
![FixedFA](https://user-images.githubusercontent.com/3128126/156604812-32da3a92-bd89-4883-a6d5-95bd227d3b36.gif)

