### PR TITLE
Updates to seeding. Add region

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
@@ -75,8 +75,7 @@ namespace Headstart.API.Commands
             });
 
             var portalUserToken = await _portal.Login(seed.PortalUsername, seed.PortalPassword);
-            var marketPlaceToBuild = ConstructMarketplaceFromSeed(seed, requestedEnv);
-            var marketplace = await GetOrCreateMarketplace(portalUserToken, marketPlaceToBuild);
+            var marketplace = await GetOrCreateMarketplace(portalUserToken, seed, requestedEnv); 
             var marketplaceToken = await _portal.GetMarketplaceToken(marketplace.Id, portalUserToken);
 
             await CreateOrUpdateDefaultSellerUser(seed, marketplaceToken);
@@ -181,24 +180,25 @@ namespace Headstart.API.Commands
             }
         }
 
-        public async Task<Marketplace> GetOrCreateMarketplace(string token, Marketplace marketplace)
+        public async Task<Marketplace> GetOrCreateMarketplace(string token, EnvironmentSeed seed, OcEnv env)
         {
-            if (marketplace.Id != null)
+            if (seed.MarketplaceID != null)
             {
-                var existingMarketplace = await VerifyMarketplaceExists(marketplace.Id, token);
+                var existingMarketplace = await VerifyMarketplaceExists(seed.MarketplaceID, token);
                 return existingMarketplace;
             }
             else
             {
+	            var marketPlaceToCreate = ConstructMarketplaceFromSeed(seed, env);
 	            try
                 {
-                    await _portal.GetMarketplace(marketplace.Id, token);
-                    return await GetOrCreateMarketplace(token, marketplace);
+                    await _portal.GetMarketplace(marketPlaceToCreate.Id, token);
+                    return await GetOrCreateMarketplace(token, seed, env);
                 }
                 catch (Exception ex)
                 {
-                    await _portal.CreateMarketplace(marketplace, token);
-                    return await _portal.GetMarketplace(marketplace.Id, token);
+                    await _portal.CreateMarketplace(marketPlaceToCreate, token);
+                    return await _portal.GetMarketplace(marketPlaceToCreate.Id, token);
                 }
             }
         }

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
@@ -128,8 +128,8 @@ namespace Headstart.API.Commands
 
         private static Marketplace ConstructMarketplaceFromSeed(EnvironmentSeed seed, OcEnv requestedEnv)
         {
-	        var region = seed.AsureRegion != null
-		        ? SeedConstants.Regions.Find(r => r.Name == seed.AsureRegion)
+	        var region = seed.Region != null
+		        ? SeedConstants.Regions.Find(r => r.Name == seed.Region)
 		        : SeedConstants.UsWest;
 	        return new Marketplace()
 	        {
@@ -195,7 +195,7 @@ namespace Headstart.API.Commands
                     await _portal.GetMarketplace(marketPlaceToCreate.Id, token);
                     return await GetOrCreateMarketplace(token, seed, env);
                 }
-                catch (Exception ex)
+                catch
                 {
                     await _portal.CreateMarketplace(marketPlaceToCreate, token);
                     return await _portal.GetMarketplace(marketPlaceToCreate.Id, token);

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
@@ -60,7 +60,7 @@ namespace Headstart.API.Commands
         /// </summary>
         public async Task<EnvironmentSeedResponse> Seed(EnvironmentSeed seed)
         {
-            OcEnv requestedEnv = validateEnvironment(seed.OrderCloudSettings.Environment);
+            OcEnv requestedEnv = validateEnvironment(seed.OrderCloudSeedSettings.Environment);
 
             if (requestedEnv.environmentName == OrderCloudEnvironments.Production.environmentName && seed.MarketplaceID == null)
             {
@@ -573,7 +573,7 @@ namespace Headstart.API.Commands
 
             // this gets called by both the /seed command and the post-staging restore so we need to handle getting settings from two sources
             var middlewareBaseUrl = seed != null ? seed.MiddlewareBaseUrl : _settings.EnvironmentSettings.MiddlewareBaseUrl;
-            var webhookHashKey = seed != null ? seed.OrderCloudSettings.WebhookHashKey : _settings.OrderCloudSettings.WebhookHashKey;
+            var webhookHashKey = seed != null ? seed.OrderCloudSeedSettings.WebhookHashKey : _settings.OrderCloudSettings.WebhookHashKey;
             var checkoutEvent = SeedConstants.CheckoutEvent(middlewareBaseUrl, webhookHashKey);
             await _oc.IntegrationEvents.SaveAsync(checkoutEvent.ID, checkoutEvent, token);
             var localCheckoutEvent = SeedConstants.LocalCheckoutEvent(webhookHashKey);

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
@@ -224,7 +224,7 @@ namespace Headstart.API.Commands
                         // MessageType.ShipmentCreated this is currently being triggered in-app possibly move to message senders
                     },
                 URL = seed.MiddlewareBaseUrl + "/messagesenders/{messagetype}",
-                SharedKey = seed.OrderCloudSettings.WebhookHashKey
+                SharedKey = seed.OrderCloudSeedSettings.WebhookHashKey
             };
         }
 
@@ -238,7 +238,7 @@ namespace Headstart.API.Commands
                         MessageType.ForgottenPassword,
                     },
                 URL = seed.MiddlewareBaseUrl + "/messagesenders/{messagetype}",
-                SharedKey = seed.OrderCloudSettings.WebhookHashKey
+                SharedKey = seed.OrderCloudSeedSettings.WebhookHashKey
             };
         }
 
@@ -252,7 +252,7 @@ namespace Headstart.API.Commands
                         MessageType.ForgottenPassword,
                     },
                 URL = seed.MiddlewareBaseUrl + "/messagesenders/{messagetype}",
-                SharedKey = seed.OrderCloudSettings.WebhookHashKey
+                SharedKey = seed.OrderCloudSeedSettings.WebhookHashKey
             };
         }
         #endregion

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
@@ -363,5 +363,55 @@ namespace Headstart.API.Commands
 
         #endregion
 
+        #region Azure Regions
+
+        public static Region UsEast = new Region()
+        {
+	        AzureRegion = "eastus",
+	        Id = "est",
+	        Name = "US-East"
+        };
+
+        public static Region AustraliaEast = new Region()
+        {
+	        AzureRegion = "australiaeast",
+	        Id = "aus",
+	        Name = "Australia-East"
+        };
+
+        public static Region EuropeWest = new Region()
+        {
+	        AzureRegion = "westeurope",
+	        Id = "eur",
+	        Name = "Europe-West"
+        };
+
+        public static Region JapanEast = new Region()
+        {
+	        AzureRegion = "japaneast",
+	        Id = "jpn",
+	        Name = "Japan-East"
+        };
+
+        public static Region UsWest = new Region()
+        {
+	        AzureRegion = "westus",
+	        Id = "usw",
+	        Name = "Us-West"
+        };
+
+        public static readonly List<Region> Regions = new List<Region>()
+        {
+            UsEast,
+            AustraliaEast,
+            EuropeWest,
+            JapanEast,
+            UsWest
+        };
+
+
+
+        #endregion
+
     }
 }

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
@@ -397,7 +397,7 @@ namespace Headstart.API.Commands
         {
 	        AzureRegion = "westus",
 	        Id = "usw",
-	        Name = "Us-West"
+	        Name = "US-West"
         };
 
         public static readonly List<Region> Regions = new List<Region>()

--- a/src/Middleware/src/Headstart.Common/Assets/SeedTemplate.json
+++ b/src/Middleware/src/Headstart.Common/Assets/SeedTemplate.json
@@ -7,6 +7,7 @@
   "MarketplaceID": "",
   "OrderCloudSeedSettings": {
     "Environment": "sandbox",
+    "Region": "Us-West",
     "WebhookHashKey": ""
   },
   "StorageAccountSettings": {

--- a/src/Middleware/src/Headstart.Common/Assets/SeedTemplate.json
+++ b/src/Middleware/src/Headstart.Common/Assets/SeedTemplate.json
@@ -5,7 +5,7 @@
   "InitialAdminPassword": "",
   "MiddlewareBaseUrl": "",
   "MarketplaceID": "",
-  "OrderCloudSettings": {
+  "OrderCloudSeedSettings": {
     "Environment": "sandbox",
     "WebhookHashKey": ""
   },

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -48,7 +48,7 @@ namespace Headstart.Models.Misc
 		/// Container for OrderCloud Settings
 		/// </summary>
 		[Required]
-		public OrderCloudSeedSettings OrderCloudSettings { get; set; }
+		public OrderCloudSeedSettings OrderCloudSeedSettings { get; set; }
 
 		#endregion
 

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -166,4 +166,12 @@ namespace Headstart.Models.Misc
         public string environmentName { get; set; }
 		public string apiUrl { get; set; }
     }
+
+	public class Region
+	{
+		public string AzureRegion { get; set; }
+		public string Id { get; set; }
+		public string Name { get; set; }
+		
+	}
 }

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -95,6 +95,14 @@ namespace Headstart.Models.Misc
 		/// </summary>
 		public StorageAccountSeedSettings StorageAccountSettings { get; set; }
 
+		/// <summary>
+		/// Optionally provide an region for your new marketplace to be stored.
+		/// Options are US-West, US-East, Australia-East, Europe-West, Japan-East.
+		/// If no value is provided US-West will be used by default.
+		/// </summary>
+		[ValueRange(AllowableValues = new[] { "US-East", "Australia-East", "Europe-West", "Japan-East", "US-West"})]
+		public string AsureRegion { get; set; }
+
         #endregion
     }
 

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -100,7 +100,7 @@ namespace Headstart.Models.Misc
 		/// Options are US-West, US-East, Australia-East, Europe-West, Japan-East.
 		/// If no value is provided US-West will be used by default.
 		/// </summary>
-		[ValueRange(AllowableValues = new[] { "US-East", "Australia-East", "Europe-West", "Japan-East", "US-West"})]
+		[ValueRange(AllowableValues = new[] {null, "US-East", "Australia-East", "Europe-West", "Japan-East", "US-West"})]
 		public string AsureRegion { get; set; }
 
         #endregion

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -96,12 +96,13 @@ namespace Headstart.Models.Misc
 		public StorageAccountSeedSettings StorageAccountSettings { get; set; }
 
 		/// <summary>
-		/// Optionally provide an region for your new marketplace to be stored.
+		/// Optionally provide an region for your new marketplace to be hosted in.
 		/// Options are US-West, US-East, Australia-East, Europe-West, Japan-East.
 		/// If no value is provided US-West will be used by default.
+		/// https://ordercloud.io/knowledge-base/ordercloud-regions
 		/// </summary>
 		[ValueRange(AllowableValues = new[] {null, "US-East", "Australia-East", "Europe-West", "Japan-East", "US-West"})]
-		public string AsureRegion { get; set; }
+		public string Region { get; set; }
 
         #endregion
     }

--- a/src/Middleware/src/Headstart.Common/Services/Portal/Models/Organization.cs
+++ b/src/Middleware/src/Headstart.Common/Services/Portal/Models/Organization.cs
@@ -1,10 +1,12 @@
-﻿namespace Headstart.Common.Services.Portal.Models
+﻿using Headstart.Models.Misc;
+
+namespace Headstart.Common.Services.Portal.Models
 {
     public class Marketplace
     {
+	    public string Environment { get; set; }
         public string Id { get; set; }
         public string Name { get; set; }
-        public PortalUser Owner { get; set; }
-        public string Environment { get; set; }
+        public Region Region { get; set; }
     }
 }


### PR DESCRIPTION
1. Use the existing type `OrderCloudSeedSettings` instead of `OrderCloudSettings` The `OrderCloudSettings` type has fields that are not available at time of seeding that may be confusing to user. I believe the process previously used this type. All this type contains is the WebhookHashKey and Environment.
2. Change the name of the field `OrderCloudSettings` in the `EnvironmentSeed` type to be `OrderCloudSeedSettings` for consistency
3. Updated the PUT request to save a marketplace to have the Region data. Users can pass in a specified region or we will use US-West as the default

## Description

For Reference: [HDS-JIRANUMBER](https://four51.atlassian.net/browse/HDS-JIRANUMBER) <!--  Ignore if PR from external developer -->

- [ ] I have updated the acceptance criteria on the task so that it can be tested
