### PR TITLE
Temporarily disabled custom log file creation

### DIFF
--- a/src/Middleware/src/SitecoreExtensions/code/Extensions/SitecoreLoggingExtensions.cs
+++ b/src/Middleware/src/SitecoreExtensions/code/Extensions/SitecoreLoggingExtensions.cs
@@ -150,13 +150,15 @@ namespace Sitecore.Foundation.SitecoreExtensions.Extensions
 			message = GetLogExceptionMessage(methodName, $@"{messageKeyValue}: {message}", string.Empty, string.Empty, GetApiResponseMessagePrefixKey());
 			if (isError)
 			{
-				WriteToCustomLogFile(appLogFileKey, methodName, message, true, tryCatchMessage, errorTraceCert);
+				//Todo: Need to renable on permission issue is resolved for creacting log files
+				//WriteToCustomLogFile(appLogFileKey, methodName, message, true, tryCatchMessage, errorTraceCert);
 				if (origExc != null)
 				{
 					throw origExc;
 				}
 			}
-			WriteToCustomLogFile(appLogFileKey, methodName, message, false);
+			//Todo: Need to renable on permission issue is resolved for creacting log files
+			//WriteToCustomLogFile(appLogFileKey, methodName, message, false);
 		}
 
 		/// <summary>


### PR DESCRIPTION
1. Temporarily disabled custom log file creation - //Todo: Need to re-enable on permission issue is resolved for creating log files.