### PR TITLE
Verbatim identifier breaks password regex

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
@@ -147,8 +147,8 @@ namespace Headstart.API.Commands.EnvironmentSeed
 		/// <returns>The Marketplace response object</returns>
 		private static Marketplace ConstructMarketplaceFromSeed(Common.Models.Misc.EnvironmentSeed seed, OcEnv requestedEnv)
 		{
-			var region = seed.Region != null
-				? SeedConstants.Regions.Find(r => r.Name == seed.Region)
+			var region = !string.IsNullOrWhiteSpace(seed.Region)
+				? SeedConstants.Regions.Find(r => r.Name.Equals(seed.Region, StringComparison.OrdinalIgnoreCase))
 				: SeedConstants.UsWest;
 			return new Marketplace()
 			{

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/EnvironmentSeedCommand.cs
@@ -74,8 +74,8 @@ namespace Headstart.API.Commands.EnvironmentSeed
 			var resp = new EnvironmentSeedResponse();
 			try 
 			{
-				var requestedEnv = ValidateEnvironment(seed.OrderCloudSeedSettings.Environment);
-				if (requestedEnv.EnvironmentName == OrderCloudEnvironments.Production.EnvironmentName && seed.MarketplaceId == null)
+				var requestedEnv = SeedConstants.OrderCloudEnvironment(seed.OrderCloudSeedSettings.Environment, seed.Region);
+				if (requestedEnv.EnvironmentName.Equals(SeedConstants.Environments.Production, StringComparison.OrdinalIgnoreCase) && seed.MarketplaceId == null)
 				{
 					var exception = $@"Cannot create a production environment via the environment seed endpoint. Please contact an OrderCloud Developer to create a production marketplace.";
 					LogExt.LogException(_settings.LogSettings, Helpers.GetMethodName(), $@"{LoggingNotifications.GetGeneralLogMessagePrefixKey()}", exception, "", this, true);
@@ -147,17 +147,14 @@ namespace Headstart.API.Commands.EnvironmentSeed
 		/// <returns>The Marketplace response object</returns>
 		private static Marketplace ConstructMarketplaceFromSeed(Common.Models.Misc.EnvironmentSeed seed, OcEnv requestedEnv)
 		{
-			var region = !string.IsNullOrWhiteSpace(seed.Region)
-				? SeedConstants.Regions.Find(r => r.Name.Equals(seed.Region, StringComparison.OrdinalIgnoreCase))
-				: SeedConstants.UsWest;
 			return new Marketplace()
 			{
 				Id = Guid.NewGuid().ToString(),
 				Environment = requestedEnv.EnvironmentName,
-				Name = string.IsNullOrEmpty(seed.MarketplaceName) 
-					? @"My Headstart Marketplace" 
+				Name = string.IsNullOrEmpty(seed.MarketplaceName)
+					? @"My Headstart Marketplace"
 					: seed.MarketplaceName,
-				Region = region
+				Region = requestedEnv.Region
 			};
 		}
 
@@ -185,32 +182,6 @@ namespace Headstart.API.Commands.EnvironmentSeed
 			{
 				LogExt.LogException(_settings.LogSettings, Helpers.GetMethodName(), $@"{LoggingNotifications.GetGeneralLogMessagePrefixKey()}", ex.Message, ex.StackTrace, this, true);
 			}
-		}
-
-		/// <summary>
-		/// Private re-usable ValidateEnvironment method
-		/// </summary>
-		/// <param name="environment"></param>
-		/// <returns>The OcEnv response object</returns>
-		private OcEnv ValidateEnvironment(string environment)
-		{
-			OcEnv resp = null;
-			try
-			{
-				if (environment.Trim().Equals(@"production", StringComparison.OrdinalIgnoreCase))
-				{
-					return OrderCloudEnvironments.Production;
-				}
-				else if (environment.Trim().Equals(@"sandbox", StringComparison.OrdinalIgnoreCase))
-				{
-					return OrderCloudEnvironments.Sandbox;
-				}
-			}
-			catch (Exception ex)
-			{
-				LogExt.LogException(_settings.LogSettings, Helpers.GetMethodName(), $@"{LoggingNotifications.GetGeneralLogMessagePrefixKey()}", ex.Message, ex.StackTrace, this, true);
-			}
-			return resp;
 		}
 
 		/// <summary>

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
@@ -610,8 +610,9 @@ namespace Headstart.API.Commands.EnvironmentSeed
 			{
 				marketplace = new OcEnv()
 				{
-					EnvironmentName = Environments.Production
-				};
+					EnvironmentName = Environments.Production,
+                    Region = envRegion
+                };
 
 				if (envRegion == UsEast)
 				{
@@ -638,8 +639,9 @@ namespace Headstart.API.Commands.EnvironmentSeed
 			{
 				marketplace = new OcEnv()
 				{
-					EnvironmentName = Environments.Sandbox
-				};
+					EnvironmentName = Environments.Sandbox,
+                    Region = envRegion
+                };
 
 				if (envRegion == UsEast)
 				{

--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
@@ -585,5 +585,85 @@ namespace Headstart.API.Commands.EnvironmentSeed
 			UsWest
 		};
 		#endregion
+
+		public static class Environments
+		{
+			public const string Production = "Production";
+			public const string Sandbox = "Sandbox";
+		};
+
+		/// <summary>
+		/// Constructs the OrderCloud environment.
+		/// </summary>
+		/// <param name="environment"></param>
+		/// <param name="region"></param>
+		/// <returns>The OcEnv response object</returns>
+		public static OcEnv OrderCloudEnvironment(string environment, string region)
+		{
+			OcEnv marketplace = null;
+
+			var envRegion = !string.IsNullOrWhiteSpace(region.Trim())
+					? Regions.Find(r => r.Name.Equals(region.Trim(), StringComparison.OrdinalIgnoreCase))
+					: UsWest;
+
+			if (environment.Trim().Equals(Environments.Production, StringComparison.OrdinalIgnoreCase))
+			{
+				marketplace = new OcEnv()
+				{
+					EnvironmentName = Environments.Production
+				};
+
+				if (envRegion == UsEast)
+				{
+					marketplace.ApiUrl = @"https://useast-production.ordercloud.io";
+				}
+				else if (envRegion == AustraliaEast)
+				{
+					marketplace.ApiUrl = @"https://australiaeast-production.ordercloud.io";
+				}
+				else if (envRegion == EuropeWest)
+				{
+					marketplace.ApiUrl = @"https://westeurope-production.ordercloud.io";
+				}
+				else if (envRegion == JapanEast)
+				{
+					marketplace.ApiUrl = @"https://japaneast-production.ordercloud.io";
+				}
+				else if (envRegion == UsWest)
+				{
+					marketplace.ApiUrl = @"https://api.ordercloud.io";
+				}
+			}
+			else if (environment.Trim().Equals(Environments.Sandbox, StringComparison.OrdinalIgnoreCase))
+			{
+				marketplace = new OcEnv()
+				{
+					EnvironmentName = Environments.Sandbox
+				};
+
+				if (envRegion == UsEast)
+				{
+					marketplace.ApiUrl = @"https://useast-sandbox.ordercloud.io";
+				}
+				else if (envRegion == AustraliaEast)
+				{
+					marketplace.ApiUrl = @"https://australiaeast-sandbox.ordercloud.io";
+				}
+				else if (envRegion == EuropeWest)
+				{
+					marketplace.ApiUrl = @"https://westeurope-sandbox.ordercloud.io";
+				}
+				else if (envRegion == JapanEast)
+				{
+					marketplace.ApiUrl = @"https://japaneast-sandbox.ordercloud.io";
+				}
+				else if (envRegion == UsWest)
+				{
+					marketplace.ApiUrl = @"https://sandboxapi.ordercloud.io";
+				}
+			}
+
+			return marketplace;
+		}
 	}
 }

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -30,7 +30,7 @@ namespace Headstart.Common.Models.Misc
 		/// The password for the admin user you will log in with after seeding
 		/// </summary>
 		[Required]
-		[StringLength(100, ErrorMessage = @"Password must be at least 8 characters long and maximum 100 characters long.", MinimumLength = 8)]
+		[StringLength(100, ErrorMessage = @"Password must be at least 10 characters long and maximum 100 characters long.", MinimumLength = 10)]
 		[RegularExpression(@"^(?=.{10,}$)(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\W).*$", ErrorMessage = @"Password must contain one number, one uppercase letter, one lowercase letter, one special character and have a minimum of 10 characters total.")]
 		public string InitialAdminPassword { get; set; } = string.Empty;
 

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Collections.Generic;
 using Headstart.Common.Models.Headstart;
 using System.ComponentModel.DataAnnotations;
+using System;
 
 namespace Headstart.Common.Models.Misc
 {
@@ -96,7 +97,7 @@ namespace Headstart.Common.Models.Misc
 		/// If no value is provided US-West will be used by default.
 		/// https://ordercloud.io/knowledge-base/ordercloud-regions
 		/// </summary>
-		[ValueRange(AllowableValues = new[] { null, "US-East", "Australia-East", "Europe-West", "Japan-East", "US-West" })]
+		[ValueRange(AllowableValues = new[] { "", null, "US-East", "Australia-East", "Europe-West", "Japan-East", "US-West" })]
 		public string Region { get; set; } = string.Empty;
 		#endregion
 	}
@@ -160,7 +161,7 @@ namespace Headstart.Common.Models.Misc
 
 		protected override ValidationResult IsValid(object value, ValidationContext validationContext)
 		{
-			if (AllowableValues?.Contains(value?.ToString().ToLower()) == true)
+			if (AllowableValues?.Contains(value?.ToString(), StringComparer.OrdinalIgnoreCase) == true)
 			{
 				return ValidationResult.Success;
 			}

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -31,7 +31,7 @@ namespace Headstart.Common.Models.Misc
 		/// </summary>
 		[Required]
 		[StringLength(100, ErrorMessage = @"Password must be at least 8 characters long and maximum 100 characters long.", MinimumLength = 8)]
-		[RegularExpression(@"^(?=.{10,}$)(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\\W).*$", ErrorMessage = @"Password must contain one number, one uppercase letter, one lowercase letter, one special character and have a minimum of 10 characters total.")]
+		[RegularExpression(@"^(?=.{10,}$)(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\W).*$", ErrorMessage = @"Password must contain one number, one uppercase letter, one lowercase letter, one special character and have a minimum of 10 characters total.")]
 		public string InitialAdminPassword { get; set; } = string.Empty;
 
 		/// <summary>

--- a/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Misc/EnvironmentSeed.cs
@@ -140,21 +140,6 @@ namespace Headstart.Common.Models.Misc
 		public string ContainerNameDownloads { get; set; } = @"downloads";
 	}
 
-	public static class OrderCloudEnvironments
-	{
-		public static readonly OcEnv Production = new OcEnv()
-		{
-			EnvironmentName = @"Production",
-			ApiUrl = @"https://api.ordercloud.io"
-		};
-
-		public static readonly OcEnv Sandbox = new OcEnv()
-		{
-			EnvironmentName = @"Sandbox",
-			ApiUrl = @"https://sandboxapi.ordercloud.io"
-		};
-	}
-
 	public class ValueRange : ValidationAttribute
 	{
 		public string[] AllowableValues { get; set; }
@@ -175,6 +160,8 @@ namespace Headstart.Common.Models.Misc
 		public string EnvironmentName { get; set; } = string.Empty;
 
 		public string ApiUrl { get; set; } = string.Empty;
+
+		public Region Region { get; set; } = null;
 	}
 
 	public class Region

--- a/src/Middleware/src/Headstart.Common/Services/Portal/PortalService.cs
+++ b/src/Middleware/src/Headstart.Common/Services/Portal/PortalService.cs
@@ -81,7 +81,7 @@ namespace Headstart.Common.Services.Portal
 		{
 			try
 			{
-				await _client.Request(@"organizations/{marketplace.Id}").WithOAuthBearerToken(token).PutJsonAsync(marketplace);
+				await _client.Request($@"organizations/{marketplace.Id}").WithOAuthBearerToken(token).PutJsonAsync(marketplace);
 			}
 			catch (Exception ex)
 			{

--- a/src/Middleware/tests/Headstart.Tests/EnvironmentSeedTests.cs
+++ b/src/Middleware/tests/Headstart.Tests/EnvironmentSeedTests.cs
@@ -1,0 +1,58 @@
+﻿using Headstart.Common.Models.Misc;
+using System.ComponentModel.DataAnnotations;
+using NUnit.Framework;
+
+namespace Headstart.Tests
+{
+    public class EnvironmentSeedTests
+	{
+		[Test]
+        [TestCase("Aa@101234")] // less than 10 characters
+        [TestCase("Aa@10123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456")] // greater than 100 characters
+        [TestCase("a@10123456")] // missing upper case
+        [TestCase("A@10123456")] // missing lower case
+        [TestCase("Aa@abcdefg")] // missing number
+        [TestCase("Aa10123456")] // missing special character
+        public void initial_admin_password_does_not_meet_minimum_requirements_fails_validation(string password)
+		{
+            // Arrange
+            var seed = new EnvironmentSeed()
+            {
+                InitialAdminPassword = password
+            };
+
+            var ctx = new ValidationContext(seed)
+            {
+                MemberName = nameof(seed.InitialAdminPassword)
+            };
+
+            // Act
+            var result = Validator.TryValidateProperty(seed.InitialAdminPassword, ctx, null);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        [TestCase("Aa@1012345")]
+        public void initial_admin_password_meets_minimum_requirements_passes_validation(string password)
+        {
+            // Arrange
+            var seed = new EnvironmentSeed()
+            {
+                InitialAdminPassword = password
+            };
+
+            var ctx = new ValidationContext(seed)
+            {
+                MemberName = nameof(seed.InitialAdminPassword)
+            };
+
+            // Act
+            var result = Validator.TryValidateProperty(seed.InitialAdminPassword, ctx, null);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+    }
+}

--- a/src/Middleware/tests/Headstart.Tests/EnvironmentSeedTests.cs
+++ b/src/Middleware/tests/Headstart.Tests/EnvironmentSeedTests.cs
@@ -54,5 +54,55 @@ namespace Headstart.Tests
             // Assert
             Assert.IsTrue(result);
         }
+
+        [Test]
+        [TestCase("other")]
+        public void region_not_in_value_range_fails_validation(string region)
+        {
+            // Arrange
+            var seed = new EnvironmentSeed()
+            {
+                Region = region
+            };
+
+            var ctx = new ValidationContext(seed)
+            {
+                MemberName = nameof(seed.Region)
+            };
+
+            // Act
+            var result = Validator.TryValidateProperty(seed.Region, ctx, null);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        [TestCase("")]
+        [TestCase(null)]
+        [TestCase("US-East")]
+        [TestCase("Australia-East")]
+        [TestCase("Europe-West")]
+        [TestCase("Japan-East")]
+        [TestCase("US-West")]
+        public void region_in_value_range_passes_validation(string region)
+        {
+            // Arrange
+            var seed = new EnvironmentSeed()
+            {
+                Region = region
+            };
+
+            var ctx = new ValidationContext(seed)
+            {
+                MemberName = nameof(seed.Region)
+            };
+
+            // Act
+            var result = Validator.TryValidateProperty(seed.Region, ctx, null);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
     }
 }


### PR DESCRIPTION
- Removed escape character that is no longer required with verbatim identifier.
- Updated StringLength validation attribute to comply with OrderCloud's new minimum password requirements from June 1st 2021.
- Added unit tests for the environment seed class to prevent inadvertent corruption in the future.