### PR TITLE
- Fixed ISupplierSyncCommand DI issue

### DIFF
--- a/src/Middleware/src/Headstart.API/Startup.cs
+++ b/src/Middleware/src/Headstart.API/Startup.cs
@@ -46,6 +46,7 @@ using ordercloud.integrations.library.cosmos_repo;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using ITaxCalculator = ordercloud.integrations.library.ITaxCalculator;
 using ITaxCodesProvider = ordercloud.integrations.library.intefaces.ITaxCodesProvider;
+using Headstart.API.Commands.SupplierSync;
 
 namespace Headstart.API
 {
@@ -198,6 +199,7 @@ namespace Headstart.API
 				.Inject<ICreditCardCommand>()
 				.Inject<ISupportAlertService>()
 				.Inject<ISupplierApiClientHelper>()
+				.Inject<ISupplierSyncCommand>()
 				.AddSingleton<ISendGridClient>(x => new SendGridClient(_settings.SendgridSettings.ApiKey))
 				.AddSingleton<IFlurlClientFactory>(x => flurlClientFactory)
 				.AddSingleton<DownloadReportCommand>()


### PR DESCRIPTION
Calling the headstart API resulted in the error "Unable to resolve service for type 'Headstart.API.Commands.SupplierSync.ISupplierSyncCommand' while attempting to activate 'Headstart.API.Commands.HsSupplierCommand'."

This fix passes the current blocker, preventing the environment seed endpoint, but may need to register a specific concrete class as the HsSupplierCommand has not been validated.