### PR TITLE
Smarty is mandatory for US addresses

### DIFF
--- a/src/Middleware/integrations/ordercloud-integrations-smartystreets/SmartyStreetsCommand.cs
+++ b/src/Middleware/integrations/ordercloud-integrations-smartystreets/SmartyStreetsCommand.cs
@@ -37,9 +37,11 @@ namespace ordercloud.integrations.smartystreets
 	{
 		private readonly ISmartyStreetsService _service;
 		private readonly IOrderCloudClient _oc;
+		private readonly SmartyStreetsConfig _settings;
 
-		public SmartyStreetsCommand(IOrderCloudClient oc, ISmartyStreetsService service)
+		public SmartyStreetsCommand(SmartyStreetsConfig settings, IOrderCloudClient oc, ISmartyStreetsService service)
 		{
+			_settings = settings;
 			_service = service;
 			_oc = oc;
 		}
@@ -47,6 +49,12 @@ namespace ordercloud.integrations.smartystreets
 		public async Task<AddressValidation> ValidateAddress(Address address)
 		{
 			var response = new AddressValidation(address);
+			if (!_settings.SmartyEnabled)
+			{
+				response.ValidAddress = address;
+				return response;
+			}
+
 			if (address.Country == "US")
 			{
 				var lookup = AddressMapper.MapToUSStreetLookup(address);

--- a/src/Middleware/integrations/ordercloud-integrations-smartystreets/SmartyStreetsConfig.cs
+++ b/src/Middleware/integrations/ordercloud-integrations-smartystreets/SmartyStreetsConfig.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ordercloud.integrations.smartystreets
+﻿namespace ordercloud.integrations.smartystreets
 {
 	public class SmartyStreetsConfig
 	{
@@ -10,5 +6,6 @@ namespace ordercloud.integrations.smartystreets
 		public string AuthToken { get; set; }
 		public string RefererHost { get; set; } // The autocomplete pro endpoint requires the Referer header to be a pre-set value 
 		public string WebsiteKey { get; set; }
+		public bool SmartyEnabled { get; set; }
 	}
 }

--- a/src/Middleware/src/Headstart.API/Startup.cs
+++ b/src/Middleware/src/Headstart.API/Startup.cs
@@ -153,6 +153,7 @@ namespace Headstart.API
                 default:
                     break;
             }
+            var smartyService = new SmartyStreetsService(_settings.SmartyStreetSettings, smartyStreetsUsClient);
             
             services.AddMvc(o =>
              {
@@ -176,7 +177,7 @@ namespace Headstart.API
                 .InjectCosmosStore<ReportTemplateQuery, ReportTemplate>(cosmosConfig)
                 .AddCosmosDb(_settings.CosmosSettings.EndpointUri, _settings.CosmosSettings.PrimaryKey, _settings.CosmosSettings.DatabaseName, cosmosContainers)
                 .Inject<IPortalService>()
-                .Inject<ISmartyStreetsCommand>()
+                .AddSingleton<ISmartyStreetsCommand>(x => new SmartyStreetsCommand(_settings.SmartyStreetSettings, orderCloudClient, smartyService))
                 .Inject<ICheckoutIntegrationCommand>()
                 .Inject<IShipmentCommand>()
                 .Inject<IOrderCommand>()
@@ -232,7 +233,7 @@ namespace Headstart.API
 					};
 				})
                 .AddSingleton<IEasyPostShippingService>(x => new EasyPostShippingService(new EasyPostConfig() { APIKey = _settings.EasyPostSettings.APIKey }))
-                .AddSingleton<ISmartyStreetsService>(x => new SmartyStreetsService(_settings.SmartyStreetSettings, smartyStreetsUsClient))
+                .AddSingleton<ISmartyStreetsService>(x => smartyService)
                 .AddSingleton<IOrderCloudIntegrationsCardConnectService>(x => new OrderCloudIntegrationsCardConnectService(_settings.CardConnectSettings, _settings.EnvironmentSettings.Environment.ToString(), flurlClientFactory))
                 .AddSingleton<IOrderCloudClient>(provider => orderCloudClient)
                 .AddSwaggerGen(c =>

--- a/src/Middleware/src/Headstart.Common/AppSettingsReadme.md
+++ b/src/Middleware/src/Headstart.Common/AppSettingsReadme.md
@@ -61,6 +61,7 @@
 |      SendgridSettings:CriticalSupportTemplateID       | (Optional) but required to send CriticalSupport emails) ID for template to be used for CriticalSupport emails                                                                                                               |
 |          ServiceBusSettings:ConnectionString          | Service bus client connection string |
 |            ServiceBusSettings:ZohoQueueName           | Intended for Zoho integration (Not used at this time) |
+|          SmartyStreetSettings:SmartyEnabled           | If disabled, the Smarty address validation will not be triggered for US addresses. |
 |              SmartyStreetSettings:AuthID              | Authentication ID used to connect with SmartyStreet |
 |            SmartyStreetSettings:AuthToken             | Authorization token used to connect with SmartyStreet |
 |           SmartyStreetSettings:RefererHost            | HTTP Header to a hostname/IP address listed with the Website Key [SmartyStreet Docs](https://smartystreets.com/docs/cloud/authentication) |


### PR DESCRIPTION
- Adding SmartyEnabled setting to SmartyStreetsConfig to allow address validation to be disabled.