### PR TITLE
Fix Add to Cart event error

### DIFF
--- a/src/UI/Buyer/src/app/services/reflektion/reflektion.service.ts
+++ b/src/UI/Buyer/src/app/services/reflektion/reflektion.service.ts
@@ -227,11 +227,11 @@ export class ReflektionService {
    */
   trackAddToCart(view: 'pdp' | 'qview' | 'cart', lineItem: HSLineItem): void {
     this.trackReflectionEvent('a2c', view, {
-      products: {
+      products: [{
         sku: lineItem.ProductID,
         price: lineItem.UnitPrice,
         quantity: lineItem.Quantity,
-      },
+      }],
     })
   }
 


### PR DESCRIPTION
When monitoring events in CEC, the a2c event was erroring because [products should be an array](https://doc.sitecore.com/discover/en/resources/Sitecore-Discover-API-Events.pdf#page=30)