### PR TITLE
Resolved lineitem xp reset

### DIFF
--- a/src/Middleware/src/Headstart.Common/Services/DiscountDistributionService.cs
+++ b/src/Middleware/src/Headstart.Common/Services/DiscountDistributionService.cs
@@ -67,7 +67,7 @@ namespace Headstart.Common.Services
 
             await Throttler.RunAsync(order.LineItems, 100, 8, async li =>
             {
-                var patch = new HSPartialLineItem() { xp = new LineItemXp() { LineTotalWithProportionalDiscounts = li.LineTotal } };
+                var patch = new HSPartialLineItem() { xp = new { LineTotalWithProportionalDiscounts = li.LineTotal } };
                 await oc.LineItems.PatchAsync(OrderDirection.All, order.Order.ID, li.ID, patch);
             });
         }


### PR DESCRIPTION
Amended patch of lineitem with concrete xp class to dynamic xp class to avoid overwriting/resetting all xp of the lineitem during the order calculate process.