### PR TITLE
Resolved create buyer user server error

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/HSCatalogCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/HSCatalogCommand.cs
@@ -93,7 +93,7 @@ namespace Headstart.API.Commands.Crud
             var existingCatalogs = await oc.UserGroups.ListAsync<HSLocationUserGroup>(buyerID, filters: "xp.Type=Catalog", pageSize: 100);
 
             // from the data extract the relevant catalogIDs
-            var expectedAssignedCatalogIDs = assignedGroups.Items?.Where(item => item?.xp?.Type == "BuyerLocation")?.SelectMany(c => c?.xp?.CatalogAssignments);
+            var expectedAssignedCatalogIDs = assignedGroups.Items?.Where(item => item?.xp?.Type == "BuyerLocation" && item?.xp?.CatalogAssignments != null)?.SelectMany(c => c?.xp?.CatalogAssignments);
             var actualAssignedCatalogIDs = assignedGroups.Items?.Where(item => item?.xp?.Type == "Catalog")?.Select(c => c.ID)?.ToList();
             var existingCatalogIDs = existingCatalogs.Items.Select(x => x.ID);
 

--- a/src/UI/Seller/src/app/buyers/components/users/buyer-user-edit/buyer-user-edit.component.html
+++ b/src/UI/Seller/src/app/buyers/components/users/buyer-user-edit/buyer-user-edit.component.html
@@ -1,14 +1,4 @@
 <div class="container-fluid">
-  <user-group-assignments
-    *ngIf="selectedResource && !isCreatingNew"
-    [isCreatingNew]="isCreatingNew"
-    userGroupType="BuyerLocation"
-    [user]="selectedResource"
-    (assignmentsToAdd)="addUserGroupAssignments($event)"
-    (hasAssignments)="userHasAssignments($event)"
-    [userPermissionsService]="buyerUserService"
-  >
-  </user-group-assignments>
   <form *ngIf="resourceForm" [formGroup]="resourceForm">
     <div class="row pt-3">
       <div class="col-md-5">
@@ -150,6 +140,16 @@
       </div>
     </div>
   </form>
+  <user-group-assignments
+    *ngIf="selectedResource && !isCreatingNew"
+    [isCreatingNew]="isCreatingNew"
+    userGroupType="BuyerLocation"
+    [user]="selectedResource"
+    (assignmentsToAdd)="addUserGroupAssignments($event)"
+    (hasAssignments)="userHasAssignments($event)"
+    [userPermissionsService]="buyerUserService"
+  >
+  </user-group-assignments>
   <user-group-assignments
     *ngIf="
       selectedResource &&


### PR DESCRIPTION
- Added additional null check in linq statement to prevent object null reference occurring when no catalog assignments are available for a BuyerLocation user group.

- Moved user-group-assignments component to bottom of form to be consistent with other user-group-assignments location. These two components may be able to be merged in the future.