### PR TITLE
Impersonation incorrectly enabled on buyer save

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/BuyerCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/BuyerCommand.cs
@@ -57,7 +57,7 @@ namespace Headstart.API.Commands
         {
             // to prevent changing buyerIDs
             superBuyer.Buyer.ID = buyerID;
-            var updatedImpersonationConfig = new ImpersonationConfig();
+            ImpersonationConfig updatedImpersonationConfig = null;
 
             var updatedBuyer = await oc.Buyers.SaveAsync<HSBuyer>(buyerID, superBuyer.Buyer);
             var updatedMarkup = await UpdateMarkup(superBuyer.Markup, superBuyer.Buyer.ID);


### PR DESCRIPTION
Resolved issue when updating buyer details the return object was incorrectly causing the impersonation control to be enabled.