### PR TITLE
Resolved buyerIncrementor id conflict with default buyer

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
+++ b/src/Middleware/src/Headstart.API/Commands/EnvironmentSeed/SeedConstants.cs
@@ -53,7 +53,7 @@ namespace Headstart.API.Commands
         {
             new Incrementor { ID = "orderIncrementor", Name = "Order Incrementor", LastNumber = 0, LeftPaddingCount = 6 },
             new Incrementor { ID = "supplierIncrementor", Name = "Supplier Incrementor", LastNumber = 0, LeftPaddingCount = 3 },
-            new Incrementor { ID = "buyerIncrementor", Name = "Buyer Incrementor", LastNumber = 0, LeftPaddingCount = 4 },
+            new Incrementor { ID = "buyerIncrementor", Name = "Buyer Incrementor", LastNumber = 1, LeftPaddingCount = 4 },
             new Incrementor { ID = "sellerLocationIncrementor", Name = "Seller Location Incrementor", LastNumber = 0, LeftPaddingCount = 4 },
         };
 


### PR DESCRIPTION
When creating an initial buyer after seeding, the buyerIncrementor creates a conflict id as the Default Buyer's ID is hard-coded to the initial value. The default buyer is also used to try and GET the buyer, so incrementing the LastNumber is the quickest and cleanest approach.