### PR TITLE
Adding cosmos tag as environment variable to the Docker Azure build pipeline

### DIFF
--- a/docker-azure-pipelines.yml
+++ b/docker-azure-pipelines.yml
@@ -25,6 +25,6 @@ stages:
 
                 $env:REGISTRY="$(container.registry)/headstart/"
                 $env:VERSION = $version
-
+                $env:COSMOS_TAG = "latest"
                 docker-compose build --parallel
                 docker-compose push


### PR DESCRIPTION
The cosmos service was added after the initial creation of the Azure Docker build pipeline. Our latest attempt failed to build the cosmos service since the COSMOS_TAG wasn't defined in the pipeline.