### PR TITLE
Allow server to build without AllowedClientIDs defined

### DIFF
--- a/src/Middleware/src/Headstart.Common/AppSettings.cs
+++ b/src/Middleware/src/Headstart.Common/AppSettings.cs
@@ -130,7 +130,7 @@ namespace Headstart.Common
     {
         public string ApiUrl { get; set; }
 
-        public string ClientIDsWithAPIAccess { get; set; } // Comma-separated list
+        public string ClientIDsWithAPIAccess { get; set; } = string.Empty; // Comma-separated list
 
         public string IncrementorPrefix { get; set; }
 


### PR DESCRIPTION
Server needs to run without any settings when seeding