### PR TITLE
fix bug where line item status isn't being updated correctly

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/LineItemCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/LineItemCommand.cs
@@ -326,7 +326,7 @@ namespace Headstart.API.Commands
                     xp = new
                     {
                         Returns = GetUpdatedChangeRequests(returnRequests, lineItemStatusChange, lineItemStatusChange.Quantity, newLineItemStatus, statusByQuantity),
-                        statusByQuantity,
+                        StatusByQuantity = statusByQuantity,
                     },
                 };
             }
@@ -338,7 +338,7 @@ namespace Headstart.API.Commands
                     xp = new
                     {
                         Cancelations = GetUpdatedChangeRequests(cancelRequests, lineItemStatusChange, lineItemStatusChange.Quantity, newLineItemStatus, statusByQuantity),
-                        statusByQuantity,
+                        StatusByQuantity = statusByQuantity,
                     },
                 };
             }
@@ -348,7 +348,7 @@ namespace Headstart.API.Commands
                 {
                     xp = new
                     {
-                        statusByQuantity,
+                        StatusByQuantity = statusByQuantity,
                     },
                 };
             }


### PR DESCRIPTION
This was happening because it was actually setting the updated statuses on statusByQuantity instead of on StatusByQuantity

Among other effects it was preventing a line item to be returned