### PR TITLE
Fix seller and buyer npm dependencies errors while building Docker images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,9 +80,9 @@ jobs:
     displayName: Build Buyer
     steps:
     - task: NodeTool@0
-      displayName: 'Use Node 16.x'
+      displayName: 'Use Node 12.x'
       inputs:
-        versionSpec: 16.x
+        versionSpec: 12.x
 
     - task: Cache@2
       displayName: 'SDK Dependencies Cache'
@@ -131,9 +131,9 @@ jobs:
     displayName: Build Seller
     steps:
     - task: NodeTool@0
-      displayName: 'Use Node 16.x'
+      displayName: 'Use Node 12.x'
       inputs:
-        versionSpec: 16.x
+        versionSpec: 12.x
 
     - task: Cache@2
       displayName: 'SDK Dependencies Cache'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
       context: .
       dockerfile: docker/build/UI/Dockerfile
       args:
-        BASE_IMAGE: node:16.15-alpine3.15
+        BASE_IMAGE: node:12.16.3-alpine
         ROLE: Seller
     labels:
       - "traefik.enable=true"
@@ -174,7 +174,7 @@ services:
       context: .
       dockerfile: docker/build/UI/Dockerfile
       args:
-        BASE_IMAGE: node:16.15-alpine3.15
+        BASE_IMAGE: node:12.16.3-alpine
         ROLE: Buyer
     labels:
       - "traefik.enable=true"


### PR DESCRIPTION
by reverting nodejs/npm version used