### PR TITLE
Update smarty address validation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -95,9 +95,7 @@ ServiceBusSettings_ZohoQueueName=""
 
 SmartyStreetSettings_AuthID=""
 SmartyStreetSettings_AuthToken=""
-SmartyStreetSettings_RefererHost=""
 SmartyStreetSettings_SmartyEnabled="false"
-SmartyStreetSettings_WebsiteKey=""
 
 StorageAccountSettings_ConnectionString="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://storage:10000/devstoreaccount1;QueueEndpoint=http://storage:10001/devstoreaccount1;"
 StorageAccountSettings_ContainerNameCache="cache"

--- a/assets/templates/AppSettingConfigTemplate.json
+++ b/assets/templates/AppSettingConfigTemplate.json
@@ -69,8 +69,6 @@
   "ServiceBusSettings:ZohoQueueName": "",
   "SmartyStreetSettings:AuthID": "",
   "SmartyStreetSettings:AuthToken": "",
-  "SmartyStreetSettings:RefererHost": "",
-  "SmartyStreetSettings:WebsiteKey": "",
   "TaxJarSettings:Environment": "Sandbox",
   "TaxJarSettings:ApiKey": "",
   "UI:BaseAdminUrl": "",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,9 +107,7 @@ services:
       
       SmartyStreetSettings_AuthID: "${SmartyStreetSettings_AuthID}"
       SmartyStreetSettings_AuthToken: "${SmartyStreetSettings_AuthToken}"
-      SmartyStreetSettings_RefererHost: "${SmartyStreetSettings_RefererHost}"
       SmartyStreetSettings_SmartyEnabled: "${SmartyStreetSettings_SmartyEnabled}"
-      SmartyStreetSettings_WebsiteKey: "${SmartyStreetSettings_WebsiteKey}"
 
       StorageAccountSettings_ConnectionString: "${StorageAccountSettings_ConnectionString}"
       StorageAccountSettings_HostUrl: "${StorageAccountSettings_HostUrl}"

--- a/docker/build/middleware/entrypoint.sh
+++ b/docker/build/middleware/entrypoint.sh
@@ -96,9 +96,7 @@ json -I -f appSettings.json \
 json -I -f appSettings.json \
       -e "this['SmartyStreetSettings:AuthID']='$SmartyStreetSettings_AuthID'" \
       -e "this['SmartyStreetSettings:AuthToken']='$SmartyStreetSettings_AuthToken'" \
-      -e "this['SmartyStreetSettings:RefererHost']='$SmartyStreetSettings_RefererHost'" \
-      -e "this['SmartyStreetSettings:Enabled']='$SmartyStreetSettings_SmartyEnabled'" \
-      -e "this['SmartyStreetSettings:WebsiteKey']='$SmartyStreetSettings_WebsiteKey'"
+      -e "this['SmartyStreetSettings:Enabled']='$SmartyStreetSettings_SmartyEnabled'"
 
 json -I -f appSettings.json \
       -e "this['StorageAccountSettings:ConnectionString']='$StorageAccountSettings_ConnectionString'" \

--- a/src/Middleware/integrations/OrderCloud.Integrations.Smarty/SmartyStreetsConfig.cs
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Smarty/SmartyStreetsConfig.cs
@@ -6,8 +6,5 @@
 
         public string AuthToken { get; set; }
 
-        public string RefererHost { get; set; } // The autocomplete pro endpoint requires the Referer header to be a pre-set value
-
-        public string WebsiteKey { get; set; }
     }
 }

--- a/src/Middleware/integrations/OrderCloud.Integrations.Smarty/SmartyStreetsService.cs
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Smarty/SmartyStreetsService.cs
@@ -39,9 +39,9 @@ namespace OrderCloud.Integrations.Smarty
         {
             var suggestions = await autoCompleteBaseUrl
                 .AppendPathSegment("lookup")
-                .SetQueryParam("key", config.WebsiteKey)
+                .SetQueryParam("auth-id", config.AuthID)
+                .SetQueryParam("auth-token", config.AuthToken)
                 .SetQueryParam("search", search)
-                .WithHeader("Referer", config.RefererHost)
                 .GetJsonAsync<AutoCompleteResponse>();
 
             return suggestions;

--- a/src/Middleware/src/Headstart.API/AppSettingsReadme.md
+++ b/src/Middleware/src/Headstart.API/AppSettingsReadme.md
@@ -70,8 +70,6 @@
 |            ServiceBusSettings:ZohoQueueName           | Intended for Zoho integration (Not used at this time) |
 |              SmartyStreetSettings:AuthID              | Authentication ID used to connect with SmartyStreet |
 |            SmartyStreetSettings:AuthToken             | Authorization token used to connect with SmartyStreet |
-|           SmartyStreetSettings:RefererHost            | HTTP Header to a hostname/IP address listed with the Website Key [SmartyStreet Docs](https://smartystreets.com/docs/cloud/authentication) |
-|            SmartyStreetSettings:WebsiteKey            | A unique key that can be associated with one or more hostnames. [SmartyStreet Docs](https://smartystreets.com/docs/cloud/authentication) |
 |               TaxJarSettings:Environment              | (Optional) The TaxJar environment, "Sandbox" or "Production" |
 |                 TaxJarSettings:ApiKey                 | (Optional) The TaxJar API key |
 |                    UI:BaseAdminUrl                    | URL to the admin app used                                                                                                                                                                                                   |


### PR DESCRIPTION
Smarty has notified us that as of 06/23/2022 any API calls that occur on the server to their API will be blocked unless they include the secret keys in the request. Previous to this pull request we were using clientside "credentials", this PR removes those credentials and replaces them with their server side equivalent