### PR TITLE
Fix small translation bug

### DIFF
--- a/src/Middleware/src/Headstart.Common/Models/Headstart/HSUser.cs
+++ b/src/Middleware/src/Headstart.Common/Models/Headstart/HSUser.cs
@@ -9,12 +9,14 @@ namespace Headstart.Common.Models
 
     public class UserXp
     {
-    public string Country { get; set; }
+        public string Country { get; set; }
 
-    public string OrderEmails { get; set; }
+        public string OrderEmails { get; set; }
 
-    public string RequestInfoEmails { get; set; }
+        public string RequestInfoEmails { get; set; }
 
-    public List<string> AddtlRcpts { get; set; }
+        public List<string> AddtlRcpts { get; set; }
+
+        public string Language { get; set; }
     }
 }

--- a/src/UI/Buyer/src/app/models/profile.types.ts
+++ b/src/UI/Buyer/src/app/models/profile.types.ts
@@ -1,65 +1,63 @@
-import { HSLocationUserGroup } from "@ordercloud/headstart-sdk";
-import { MeUser } from "ordercloud-javascript-sdk";
-import { CurrencyCode } from "./currency.types";
+import { HSLocationUserGroup, HSMeUser } from '@ordercloud/headstart-sdk'
+import { CurrencyCode } from './currency.types'
 
+export interface DecodedOCToken {
+  /**
+   * the ordercloud username
+   */
+  usr: string
 
-  export interface DecodedOCToken {
-    /**
-     * the ordercloud username
-     */
-    usr: string
-  
-    /**
-     * the client id used when making token request
-     */
-    cid: string
-  
-    /**
-     * helpful for identifying user types in an app
-     * that may have both types
-     */
-    usrtype: 'admin' | 'buyer'
-  
-    /**
-     * list of security profile roles that this user
-     * has access to, read more about security profile roles
-     * [here](https://developer.ordercloud.io/documentation/platform-guides/authentication/security-profiles)
-     */
-    role: string[] // TODO: add security profile roles to the sdk
-  
-    /**
-     * the issuer of the token - should always be https://auth.ordercloud.io
-     */
-    iss: string
-  
-    /**
-     * the audience - who should be consuming this token
-     * this should always be https://api.ordercloud.io (the ordercloud api)
-     */
-    aud: string
-  
-    /**
-     * expiration of the token (in seconds) since the
-     * UNIX epoch (January 1, 1970 00:00:00 UTC)
-     */
-    exp: number
-  
-    /**
-     * point at which token was issued (in seconds) since the
-     * UNIX epoch (January 1, 1970 00:00:00 UTC)
-     */
-    nbf: number
-  
-    /**
-     * the order id assigned to the anonymous user,
-     * this value will *only* exist for anonymous users
-     */
-    orderid?: string
-  }
+  /**
+   * the client id used when making token request
+   */
+  cid: string
 
-  export interface CurrentUser extends MeUser {
-    FavoriteProductIDs: string[]
-    FavoriteOrderIDs: string[]
-    UserGroups: HSLocationUserGroup[]
-    Currency: CurrencyCode
-  }
+  /**
+   * helpful for identifying user types in an app
+   * that may have both types
+   */
+  usrtype: 'admin' | 'buyer'
+
+  /**
+   * list of security profile roles that this user
+   * has access to, read more about security profile roles
+   * [here](https://developer.ordercloud.io/documentation/platform-guides/authentication/security-profiles)
+   */
+  role: string[] // TODO: add security profile roles to the sdk
+
+  /**
+   * the issuer of the token - should always be https://auth.ordercloud.io
+   */
+  iss: string
+
+  /**
+   * the audience - who should be consuming this token
+   * this should always be https://api.ordercloud.io (the ordercloud api)
+   */
+  aud: string
+
+  /**
+   * expiration of the token (in seconds) since the
+   * UNIX epoch (January 1, 1970 00:00:00 UTC)
+   */
+  exp: number
+
+  /**
+   * point at which token was issued (in seconds) since the
+   * UNIX epoch (January 1, 1970 00:00:00 UTC)
+   */
+  nbf: number
+
+  /**
+   * the order id assigned to the anonymous user,
+   * this value will *only* exist for anonymous users
+   */
+  orderid?: string
+}
+
+export interface CurrentUser extends HSMeUser {
+  FavoriteProductIDs: string[]
+  FavoriteOrderIDs: string[]
+  UserGroups: HSLocationUserGroup[]
+  Currency: CurrencyCode
+}

--- a/src/UI/Buyer/src/app/services/language-selector/language-selector.service.ts
+++ b/src/UI/Buyer/src/app/services/language-selector/language-selector.service.ts
@@ -43,20 +43,18 @@ export class LanguageSelectorService {
       }
     }
 
-    this.cookieService.putObject(this.languageCookieName, language)
+    this.cookieService.put(this.languageCookieName, language)
     this.SetTranslateLanguage()
   }
 
   /**
    * Implicitly sets the language used by the translate service
    */
-  public async SetTranslateLanguage(): Promise<void> {
+  public SetTranslateLanguage(): void {
     const browserCultureLang = this.translate.getBrowserCultureLang()
     const browserLang = this.translate.getBrowserLang()
     const languages = this.translate.getLangs()
-    const selectedLang = this.cookieService
-      .getObject(this.languageCookieName)
-      ?.toString()
+    const selectedLang = this.cookieService.get(this.languageCookieName)
     const isAnonymousUser = this.tokenHelper.isTokenAnonymous()
     let xpLang
 
@@ -65,19 +63,24 @@ export class LanguageSelectorService {
       xpLang = user?.xp?.Language
     }
     if (xpLang) {
-      this.translate.use(xpLang)
+      this.useLanguage(xpLang)
     } else if (selectedLang && languages.includes(selectedLang)) {
-      this.translate.use(selectedLang)
+      this.useLanguage(selectedLang)
     } else if (languages.includes(browserCultureLang)) {
-      this.translate.use(browserCultureLang)
+      this.useLanguage(browserCultureLang)
     } else if (languages.includes(browserLang)) {
-      this.translate.use(browserLang)
+      this.useLanguage(browserLang)
     } else if (languages.includes(this.appConfig.defaultLanguage)) {
-      this.translate.use(this.appConfig.defaultLanguage)
+      this.useLanguage(this.appConfig.defaultLanguage)
     } else if (languages.length > 0) {
-      this.translate.use(languages[0])
+      this.useLanguage(languages[0])
     } else {
       throw new Error('Cannot identify a language to use.')
     }
+  }
+
+  private useLanguage(language: string) {
+    this.translate.use(language)
+    this.cookieService.put(this.languageCookieName, language)
   }
 }

--- a/src/UI/Buyer/src/app/services/language-selector/language-selector.service.ts
+++ b/src/UI/Buyer/src/app/services/language-selector/language-selector.service.ts
@@ -37,12 +37,14 @@ export class LanguageSelectorService {
 
       const patchLangXp = {
         xp: {
-          Language: language
-        }
+          Language: language,
+        },
       }
       await this.currentUserService.patch(patchLangXp)
     } else {
-      const selectedLang = this.cookieService.getObject(this.languageCookieName)?.toString()
+      const selectedLang = this.cookieService
+        .getObject(this.languageCookieName)
+        ?.toString()
       if (selectedLang == language) {
         return
       }
@@ -56,25 +58,27 @@ export class LanguageSelectorService {
    * Implicitly sets the language used by the translate service
    */
   public async SetTranslateLanguage(): Promise<void> {
-    const browserCultureLang = this.translate.getBrowserCultureLang();
-    const browserLang = this.translate.getBrowserLang();
+    const browserCultureLang = this.translate.getBrowserCultureLang()
+    const browserLang = this.translate.getBrowserLang()
     const languages = this.translate.getLangs()
-    const selectedLang = this.cookieService.getObject(this.languageCookieName)?.toString()
+    const selectedLang = this.cookieService
+      .getObject(this.languageCookieName)
+      ?.toString()
     const isAnonymousUser = this.tokenHelper.isTokenAnonymous()
     let xpLang
-      
-    if (!isAnonymousUser){
+
+    if (!isAnonymousUser) {
       const user = this.currentUserService.get()
       xpLang = user?.xp?.Language
     }
     if (xpLang) {
-      this.translate.use(xpLang);
+      this.translate.use(xpLang)
     } else if (selectedLang && languages.includes(selectedLang)) {
-      this.translate.use(selectedLang);
+      this.translate.use(selectedLang)
     } else if (languages.includes(browserCultureLang)) {
-      this.translate.use(browserCultureLang);
+      this.translate.use(browserCultureLang)
     } else if (languages.includes(browserLang)) {
-      this.translate.use(browserLang);
+      this.translate.use(browserLang)
     } else if (languages.includes(this.appConfig.defaultLanguage)) {
       this.translate.use(this.appConfig.defaultLanguage)
     } else if (languages.length > 0) {

--- a/src/UI/Buyer/src/app/services/language-selector/language-selector.service.ts
+++ b/src/UI/Buyer/src/app/services/language-selector/language-selector.service.ts
@@ -13,20 +13,13 @@ export class LanguageSelectorService {
     .replace(/ /g, '_')
     .toLowerCase()}_selectedLang`
 
-  /**
-   * @ignore
-   * not part of public api, don't include in generated docs
-   */
   constructor(
     private currentUserService: CurrentUserService,
     private cookieService: CookieService,
     private translate: TranslateService,
     private tokenHelper: TokenHelperService,
     private appConfig: AppConfig
-  ) {
-    this.SetLanguage = this.SetLanguage.bind(this)
-    this.SetTranslateLanguage = this.SetTranslateLanguage.bind(this)
-  }
+  ) {}
 
   public async SetLanguage(language: string): Promise<void> {
     if (!this.tokenHelper.isTokenAnonymous()) {

--- a/src/UI/SDK/files-changed-hash
+++ b/src/UI/SDK/files-changed-hash
@@ -1,1 +1,1 @@
-ch9lxASXQLUYMn0mD/joVZXlXFA=
+ue0jrMKvQzw9z1LOnslFjF+uRS0=

--- a/src/UI/SDK/src/models/HSMeUser.ts
+++ b/src/UI/SDK/src/models/HSMeUser.ts
@@ -1,0 +1,3 @@
+import { MeUser } from 'ordercloud-javascript-sdk';
+import { UserXp } from './UserXp';
+export type HSMeUser = MeUser<UserXp>

--- a/src/UI/SDK/src/models/UserXp.ts
+++ b/src/UI/SDK/src/models/UserXp.ts
@@ -4,4 +4,5 @@ export interface UserXp {
     OrderEmails?: string
     RequestInfoEmails?: string
     AddtlRcpts?: string[]
+    Language?: string
 }

--- a/src/UI/SDK/src/models/index.ts
+++ b/src/UI/SDK/src/models/index.ts
@@ -26,6 +26,7 @@ export * from './HSLineItemOrder';
 export * from './HSLocationUserGroup';
 export * from './HSLocationUserGroupXp';
 export * from './HSMeProduct';
+export * from './HSMeUser';
 export * from './HSOrder';
 export * from './HSOrderLineItemData';
 export * from './HSPayment';

--- a/src/UI/Seller/src/app/layout/header/header.component.ts
+++ b/src/UI/Seller/src/app/layout/header/header.component.ts
@@ -68,11 +68,11 @@ export class HeaderComponent implements OnInit {
     this.languages = this.translate.getLangs()
     this.selectedLanguage = this.translate.currentLang
     this.translate.onLangChange.subscribe((event) => {
-      this.selectedLanguage = event.lang;
+      this.selectedLanguage = event.lang
     })
   }
 
-  async getCurrentUser() {
+  async getCurrentUser(): Promise<void> {
     this.isSupplierUser = await this.currentUserService.isSupplierUser()
     if (this.isSupplierUser) {
       this.getSupplierOrg()
@@ -81,7 +81,7 @@ export class HeaderComponent implements OnInit {
     }
   }
 
-  async getSupplierOrg() {
+  async getSupplierOrg(): Promise<void> {
     const mySupplier = await this.currentUserService.getMySupplier()
     this.organizationName = mySupplier.Name
   }
@@ -101,7 +101,7 @@ export class HeaderComponent implements OnInit {
     })
   }
 
-  urlChange = (url: string) => {
+  urlChange = (url: string): void => {
     const activeNavGroup = this.headerConfig.find((grouping) => {
       return (
         (url.includes(grouping.route) && grouping.subRoutes) ||
@@ -111,7 +111,7 @@ export class HeaderComponent implements OnInit {
     this.activeTitle = activeNavGroup && activeNavGroup.title
   }
 
-  logout() {
+  logout(): void {
     this.ocTokenService.RemoveAccess()
     this.appStateService.isLoggedIn.next(false)
     this.router.navigate(['/login'])
@@ -121,7 +121,7 @@ export class HeaderComponent implements OnInit {
     this.router.navigate(['account'])
   }
 
-  async setLanguage(language: string) {
+  async setLanguage(language: string): Promise<void> {
     const user = await this.currentUserService.refreshUser()
     await this.languageService.SetLanguage(language, user)
   }

--- a/src/UI/Seller/src/app/shared/services/language-selector/language-selector.service.ts
+++ b/src/UI/Seller/src/app/shared/services/language-selector/language-selector.service.ts
@@ -36,8 +36,8 @@ export class LanguageSelectorService {
     const accessToken = this.ocTokenService.GetAccess()
     const patchLangXp = {
       xp: {
-        Language: language
-      }
+        Language: language,
+      },
     }
     await Me.Patch(patchLangXp, { accessToken: accessToken })
 
@@ -49,25 +49,27 @@ export class LanguageSelectorService {
    * Implicitly sets the language used by the translate service
    */
   public async SetTranslateLanguage(): Promise<void> {
-    const browserCultureLang = this.translate.getBrowserCultureLang();
-    const browserLang = this.translate.getBrowserLang();
+    const browserCultureLang = this.translate.getBrowserCultureLang()
+    const browserLang = this.translate.getBrowserLang()
     const languages = this.translate.getLangs()
-    const selectedLang = this.cookieService.getObject(this.languageCookieName)?.toString()
+    const selectedLang = this.cookieService
+      .getObject(this.languageCookieName)
+      ?.toString()
     const accessToken = this.ocTokenService.GetAccess()
     let xpLang
-      
-    if (accessToken){
+
+    if (accessToken) {
       const user = await Me.Get({ accessToken: accessToken })
       xpLang = user?.xp?.Language
     }
     if (xpLang) {
-      this.translate.use(xpLang);
+      this.translate.use(xpLang)
     } else if (selectedLang && languages.includes(selectedLang)) {
-      this.translate.use(selectedLang);
+      this.translate.use(selectedLang)
     } else if (languages.includes(browserCultureLang)) {
-      this.translate.use(browserCultureLang);
+      this.translate.use(browserCultureLang)
     } else if (languages.includes(browserLang)) {
-      this.translate.use(browserLang);
+      this.translate.use(browserLang)
     } else if (languages.includes(this.appConfig.defaultLanguage)) {
       this.translate.use(this.appConfig.defaultLanguage)
     } else if (languages.length > 0) {

--- a/src/UI/Seller/src/app/shared/services/language-selector/language-selector.service.ts
+++ b/src/UI/Seller/src/app/shared/services/language-selector/language-selector.service.ts
@@ -15,10 +15,6 @@ export class LanguageSelectorService {
     .replace(/ /g, '_')
     .toLowerCase()}_selectedLang`
 
-  /**
-   * @ignore
-   * not part of public api, don't include in generated docs
-   */
   constructor(
     private ocTokenService: OcTokenService,
     private cookieService: CookieService,
@@ -28,6 +24,7 @@ export class LanguageSelectorService {
 
   public async SetLanguage(language: string, user?: HSMeUser): Promise<void> {
     if (user?.xp?.Language == language) {
+      this.cookieService.put(this.languageCookieName, language)
       return
     }
 
@@ -39,7 +36,6 @@ export class LanguageSelectorService {
     }
     await Me.Patch(patchLangXp, { accessToken: accessToken })
 
-    this.cookieService.putObject(this.languageCookieName, language)
     this.SetTranslateLanguage()
   }
 
@@ -50,9 +46,7 @@ export class LanguageSelectorService {
     const browserCultureLang = this.translate.getBrowserCultureLang()
     const browserLang = this.translate.getBrowserLang()
     const languages = this.translate.getLangs()
-    const selectedLang = this.cookieService
-      .getObject(this.languageCookieName)
-      ?.toString()
+    const selectedLang = this.cookieService.get(this.languageCookieName)
     const accessToken = this.ocTokenService.GetAccess()
     let xpLang
 
@@ -61,19 +55,24 @@ export class LanguageSelectorService {
       xpLang = user?.xp?.Language
     }
     if (xpLang) {
-      this.translate.use(xpLang)
+      this.useLanguage(xpLang)
     } else if (selectedLang && languages.includes(selectedLang)) {
-      this.translate.use(selectedLang)
+      this.useLanguage(selectedLang)
     } else if (languages.includes(browserCultureLang)) {
-      this.translate.use(browserCultureLang)
+      this.useLanguage(browserCultureLang)
     } else if (languages.includes(browserLang)) {
-      this.translate.use(browserLang)
+      this.useLanguage(browserLang)
     } else if (languages.includes(this.appConfig.defaultLanguage)) {
-      this.translate.use(this.appConfig.defaultLanguage)
+      this.useLanguage(this.appConfig.defaultLanguage)
     } else if (languages.length > 0) {
-      this.translate.use(languages[0])
+      this.useLanguage(languages[0])
     } else {
       throw new Error('Cannot identify a language to use.')
     }
+  }
+
+  private useLanguage(language: string) {
+    this.translate.use(language)
+    this.cookieService.put(this.languageCookieName, language)
   }
 }

--- a/src/UI/Seller/src/app/shared/services/language-selector/language-selector.service.ts
+++ b/src/UI/Seller/src/app/shared/services/language-selector/language-selector.service.ts
@@ -2,9 +2,10 @@ import { Inject, Injectable } from '@angular/core'
 import { applicationConfiguration } from '@app-seller/config/app.config'
 import { TranslateService } from '@ngx-translate/core'
 import { CookieService } from 'ngx-cookie'
-import { MeUser, Me } from 'ordercloud-javascript-sdk'
+import { Me } from 'ordercloud-javascript-sdk'
 import { AppConfig } from '@app-seller/models/environment.types'
 import { OcTokenService } from '@ordercloud/angular-sdk'
+import { HSMeUser } from '@ordercloud/headstart-sdk'
 
 @Injectable({
   providedIn: 'root',
@@ -23,12 +24,9 @@ export class LanguageSelectorService {
     private cookieService: CookieService,
     private translate: TranslateService,
     @Inject(applicationConfiguration) private appConfig: AppConfig
-  ) {
-    this.SetLanguage = this.SetLanguage.bind(this)
-    this.SetTranslateLanguage = this.SetTranslateLanguage.bind(this)
-  }
+  ) {}
 
-  public async SetLanguage(language: string, user?: MeUser): Promise<void> {
+  public async SetLanguage(language: string, user?: HSMeUser): Promise<void> {
     if (user?.xp?.Language == language) {
       return
     }
@@ -59,7 +57,7 @@ export class LanguageSelectorService {
     let xpLang
 
     if (accessToken) {
-      const user = await Me.Get({ accessToken: accessToken })
+      const user = await Me.Get<HSMeUser>({ accessToken: accessToken })
       xpLang = user?.xp?.Language
     }
     if (xpLang) {


### PR DESCRIPTION
Noticed a bug where after logging out the login page did not have text translated into the last known language I had selected. Reason for this was because the method that implicitly sets the language doesn't also set the cookie

Steps to reproduce:
1. Log in
2. Select a language other than default (japanese for example)
3. Clear your cookies
4. Log in again
5. Log out, and see that your selection is not persisted and text on login page is in english



I had some formatting changes so it might be best to review changes by commit
