### PR TITLE
Updated DI for reporting.

### DIFF
--- a/src/Middleware/integrations/OrderCloud.Integrations.Reporting/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Reporting/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,37 @@
+﻿using Headstart.Common.Extensions;
+using Headstart.Common.Settings;
+using Microsoft.Extensions.DependencyInjection;
+using OrderCloud.Integrations.CosmosDB;
+using OrderCloud.Integrations.CosmosDB.Extensions;
+using OrderCloud.Integrations.Reporting.Commands;
+using OrderCloud.Integrations.Reporting.Models;
+using OrderCloud.Integrations.Reporting.Queries;
+using OrderCloud.Integrations.Reporting.Repositories;
+
+namespace OrderCloud.Integrations.Reporting.Extensions
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddDefaultReportingProvider(this IServiceCollection services, EnvironmentSettings environmentSettings, CosmosConfig cosmosConfig)
+        {
+            services
+                .AddSingleton<IDownloadReportCommand, DownloadReportCommand>()
+                .InjectCosmosStore<ReportTemplateQuery, ReportTemplate>(cosmosConfig)
+                .AddDefaultReportingRepositories();
+
+            return services;
+        }
+
+        public static IServiceCollection AddDefaultReportingRepositories(this IServiceCollection services)
+        {
+            services
+                .Inject<ISalesOrderDetailDataRepo>()
+                .Inject<IPurchaseOrderDetailDataRepo>()
+                .Inject<ILineItemDetailDataRepo>()
+                .Inject<IOrdersAndShipmentsDataRepo>()
+                .Inject<IProductDetailDataRepo>();
+
+            return services;
+        }
+    }
+}

--- a/src/Middleware/src/Headstart.API/Startup.cs
+++ b/src/Middleware/src/Headstart.API/Startup.cs
@@ -35,9 +35,7 @@ using OrderCloud.Integrations.ExchangeRates.Extensions;
 using OrderCloud.Integrations.Orchestration;
 using OrderCloud.Integrations.Orchestration.Models;
 using OrderCloud.Integrations.Portal;
-using OrderCloud.Integrations.Reporting.Commands;
-using OrderCloud.Integrations.Reporting.Models;
-using OrderCloud.Integrations.Reporting.Queries;
+using OrderCloud.Integrations.Reporting.Extensions;
 using OrderCloud.Integrations.RMAs.Extensions;
 using OrderCloud.Integrations.SendGrid.Extensions;
 using OrderCloud.Integrations.Smarty.Extensions;
@@ -153,7 +151,6 @@ namespace Headstart.API
 
                 // Configure Cosmos
                 .InjectCosmosStore<LogQuery, OrchestrationLog>(cosmosConfig)
-                .InjectCosmosStore<ReportTemplateQuery, ReportTemplate>(cosmosConfig)
                 .AddCosmosDb(settings.CosmosSettings.EndpointUri, settings.CosmosSettings.PrimaryKey, settings.CosmosSettings.DatabaseName, cosmosContainers)
 
                 // Commands
@@ -170,7 +167,6 @@ namespace Headstart.API
                 .Inject<ISupplierCommand>()
                 .Inject<ICreditCardCommand>()
                 .AddSingleton<ISupplierSyncCommand, GenericSupplierCommand>()
-                .AddSingleton<IDownloadReportCommand, DownloadReportCommand>()
 
                 // Services
                 .Inject<IPortalService>()
@@ -215,6 +211,9 @@ namespace Headstart.API
                 // OMS Providers
                 .AddZohoOMSProvider(settings.EnvironmentSettings, settings.ZohoSettings)
                 .AddDefaultOMSProvider()
+
+                // Reporting Providers
+                .AddDefaultReportingProvider(settings.EnvironmentSettings, cosmosConfig)
 
                 // Documentation
                 .AddSwaggerGen(c =>

--- a/src/Middleware/src/Headstart.Jobs/Startup.cs
+++ b/src/Middleware/src/Headstart.Jobs/Startup.cs
@@ -15,7 +15,7 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using OrderCloud.Integrations.CosmosDB;
 using OrderCloud.Integrations.CosmosDB.Extensions;
-using OrderCloud.Integrations.Reporting.Repositories;
+using OrderCloud.Integrations.Reporting.Extensions;
 using OrderCloud.SDK;
 using Polly;
 using Polly.Contrib.WaitAndRetry;
@@ -104,10 +104,7 @@ namespace Headstart.Jobs
                 .AddSingleton<ReceiveRecentPurchaseOrdersJob>()
                 .AddSingleton<ReceiveRecentLineItemsJob>()
                 .AddSingleton<ReceiveRecentOrdersAndShipmentsJob>()
-                .Inject<ISalesOrderDetailDataRepo>()
-                .Inject<IPurchaseOrderDetailDataRepo>()
-                .Inject<ILineItemDetailDataRepo>()
-                .Inject<IOrdersAndShipmentsDataRepo>()
+                .AddDefaultReportingRepositories()
                 .AddSingleton(settings)
                 .AddMvcCore().AddNewtonsoftJson(o =>
                 {


### PR DESCRIPTION
I noticed that IProductDetailDataRepo was not registered to the jobs startup, so I assume the ReceiveProductDetailsJob would also throw errors when trying to resolve this dependency.

Note, in my local I receive the error "Microsoft.Azure.Documents.DocumentClientException: Reading or replacing offers is not supported for serverless accounts.", so likely to do with how I setup CosmosDB and cannot confirm working functionality at this time.