### PR TITLE
Incorrect price schedule ID reference

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/HSProductCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/HSProductCommand.cs
@@ -128,7 +128,7 @@ namespace Headstart.API.Commands
             var priceSchedule = new PriceSchedule();
             try
             {
-                priceSchedule = await oc.PriceSchedules.GetAsync<PriceSchedule>(product.ID, token);
+                priceSchedule = await oc.PriceSchedules.GetAsync<PriceSchedule>(product.DefaultPriceScheduleID, token);
             }
             catch
             {


### PR DESCRIPTION
Updated price schedule reference to use the product's DefaultPriceScheduleID property for accurate retrieval of price schedule assigned, which may differ outside of the seller application.