### PR TITLE
Fast follow order returns: Fix issue where shipping rates not returning

### DIFF
--- a/src/Middleware/src/Headstart.API/Commands/CheckoutIntegrationCommand.cs
+++ b/src/Middleware/src/Headstart.API/Commands/CheckoutIntegrationCommand.cs
@@ -43,7 +43,7 @@ namespace Headstart.API.Commands
 
         public async Task<ShipEstimateResponse> GetRatesAsync(HSOrderCalculatePayload orderCalculatePayload)
         {
-            var shipEstimateResponse = await shippingCommand.GetRatesAsync(orderCalculatePayload.OrderWorksheet, orderCalculatePayload.ConfigData);
+            var shipEstimateResponse = await shippingCommand.GetRatesAsync(orderCalculatePayload.OrderWorksheet);
             var buyerCurrency = orderCalculatePayload.OrderWorksheet.Order.xp.Currency ?? CurrencyCode.USD;
             await shipEstimateResponse.ShipEstimates.ConvertCurrency(CurrencyCode.USD, buyerCurrency, currencyConversionService);
 


### PR DESCRIPTION
For some reason when GetRatesAsync receives a dynamic it's response becomes dynamic, and the extension method ConvertCurrency can't be found at runtime. 

This wasn't found while testing locally because I had EnvironmentSettings:ShippingProvider set to null so it never hit this block of code, only noticed when testing on hosted site