### PR TITLE
fast follow order return bugs

### DIFF
--- a/src/Middleware/integrations/OrderCloud.Integrations.CardConnect/CardConnectService.cs
+++ b/src/Middleware/integrations/OrderCloud.Integrations.CardConnect/CardConnectService.cs
@@ -109,7 +109,6 @@ namespace OrderCloud.Integrations.CardConnect
                         payment = await orderCloudClient.Payments.CreateAsync<HSPayment>(OrderDirection.Incoming, order.ID, new HSPayment
                         {
                             Type = PaymentType.CreditCard,
-                            CreditCardID = payment.CreditCardID,
                             Amount = refundAmount * -1,
                             Accepted = true,
                             OrderReturnID = orderReturnId,

--- a/src/Middleware/integrations/OrderCloud.Integrations.CardConnect/Mappers/CardConnectMapper.cs
+++ b/src/Middleware/integrations/OrderCloud.Integrations.CardConnect/Mappers/CardConnectMapper.cs
@@ -82,9 +82,9 @@ namespace OrderCloud.Integrations.CardConnect.Mappers
             return req;
         }
 
-        public static PaymentTransaction Map(Payment payment, CardConnectAuthorizationResponse response, Address ccBillingAddress = null)
+        public static HSPaymentTransaction Map(Payment payment, CardConnectAuthorizationResponse response, Address ccBillingAddress = null)
         {
-            var t = new PaymentTransaction()
+            var t = new HSPaymentTransaction()
             {
                 Amount = payment.Amount,
                 DateExecuted = DateTime.Now,
@@ -92,18 +92,27 @@ namespace OrderCloud.Integrations.CardConnect.Mappers
                 ResultMessage = response.resptext,
                 Succeeded = response.WasSuccessful(),
                 Type = "CreditCard",
-                xp = new
+                xp = new TransactionXP
                 {
-                    CardConnectResponse = response,
-                    CCBillingAddress = ccBillingAddress,
+                    CCTransactionResult = new CCTransactionResult
+                    {
+                        Succeeded = response.WasSuccessful(),
+                        Amount = payment.Amount ?? 0,
+                        TransactionID = response.retref, // retrieval reference number
+                        ResponseCode = response.respcode,
+                        AuthorizationCode = response.authcode,
+                        AVSResponseCode = response.avsresp,
+                        Message = response.resptext,
+                        merchid = response.merchid,
+                    },
                 },
             };
             return t;
         }
 
-        public static PaymentTransaction Map(Payment payment, CardConnectVoidResponse response)
+        public static HSPaymentTransaction Map(Payment payment, CardConnectVoidResponse response)
         {
-            var t = new PaymentTransaction()
+            var t = new HSPaymentTransaction()
             {
                 Amount = payment.Amount,
                 DateExecuted = DateTime.Now,
@@ -111,17 +120,27 @@ namespace OrderCloud.Integrations.CardConnect.Mappers
                 ResultMessage = response.resptext,
                 Succeeded = response.WasSuccessful(),
                 Type = "CreditCardVoidAuthorization",
-                xp = new
+                xp = new TransactionXP
                 {
-                    CardConnectResponse = response,
+                    CCTransactionResult = new CCTransactionResult
+                    {
+                        Succeeded = response.WasSuccessful(),
+                        Amount = payment.Amount ?? 0,
+                        TransactionID = response.retref, // retrieval reference number
+                        ResponseCode = response.respcode,
+                        AuthorizationCode = response.authcode,
+                        AVSResponseCode = null,
+                        Message = response.resptext,
+                        merchid = response.merchid,
+                    },
                 },
             };
             return t;
         }
 
-        public static PaymentTransaction Map(Payment payment, CardConnectRefundResponse response)
+        public static HSPaymentTransaction Map(Payment payment, CardConnectRefundResponse response)
         {
-            var t = new PaymentTransaction()
+            var t = new HSPaymentTransaction()
             {
                 Amount = payment.Amount,
                 DateExecuted = DateTime.Now,
@@ -129,17 +148,27 @@ namespace OrderCloud.Integrations.CardConnect.Mappers
                 ResultMessage = response.resptext,
                 Succeeded = response.WasSuccessful(),
                 Type = "CreditCardRefund",
-                xp = new
+                xp = new TransactionXP
                 {
-                    CardConnectResponse = response,
+                    CCTransactionResult = new CCTransactionResult
+                    {
+                        Succeeded = response.WasSuccessful(),
+                        Amount = payment.Amount ?? 0,
+                        TransactionID = response.retref, // retrieval reference number
+                        ResponseCode = response.respcode,
+                        AuthorizationCode = null,
+                        AVSResponseCode = null,
+                        Message = response.resptext,
+                        merchid = response.merchid,
+                    },
                 },
             };
             return t;
         }
 
-        public static PaymentTransaction Map(Payment payment, CardConnectCaptureResponse response)
+        public static HSPaymentTransaction Map(Payment payment, CardConnectCaptureResponse response)
         {
-            var t = new PaymentTransaction()
+            var t = new HSPaymentTransaction()
             {
                 Amount = payment.Amount,
                 DateExecuted = DateTime.Now,
@@ -147,9 +176,19 @@ namespace OrderCloud.Integrations.CardConnect.Mappers
                 ResultMessage = response.resptext,
                 Succeeded = response.WasSuccessful(),
                 Type = "CreditCardCapture",
-                xp = new
+                xp = new TransactionXP
                 {
-                    CardConnectResponse = response,
+                    CCTransactionResult = new CCTransactionResult
+                    {
+                        Succeeded = response.WasSuccessful(),
+                        Amount = payment.Amount ?? 0,
+                        TransactionID = response.retref, // retrieval reference number
+                        ResponseCode = response.respcode,
+                        AuthorizationCode = null,
+                        AVSResponseCode = null,
+                        Message = response.resptext,
+                        merchid = response.merchid,
+                    },
                 },
             };
             return t;

--- a/src/Middleware/src/Headstart.Jobs/Jobs/PaymentCaptureJob.cs
+++ b/src/Middleware/src/Headstart.Jobs/Jobs/PaymentCaptureJob.cs
@@ -111,7 +111,7 @@ namespace Headstart.Jobs
 
             if (transaction?.xp?.CCTransactionResult == null)
             {
-                throw new PaymentCaptureJobException("Missing transaction.xp.CardConnectResponse", orderID, payment.ID, transaction.ID);
+                throw new PaymentCaptureJobException("Missing transaction.xp.CCTransactionResult", orderID, payment.ID, transaction.ID);
             }
 
             var authHasBeenVoided = payment.Transactions.Any(t =>

--- a/src/UI/Buyer/src/app/components/checkout/checkout-confirm/checkout-confirm.component.html
+++ b/src/UI/Buyer/src/app/components/checkout/checkout-confirm/checkout-confirm.component.html
@@ -1,26 +1,49 @@
-<button class="btn btn-block btn-primary mb-4" [disabled]="isSubmittingOrder" (click)="saveCommentsAndSubmitOrder()"
-  translate>
+<button
+  class="btn btn-block btn-primary mb-4"
+  [disabled]="isSubmittingOrder"
+  (click)="saveCommentsAndSubmitOrder()"
+  translate
+>
   CHECKOUT.CHECKOUT_CONFIRM.SUBMIT_ORDER
 </button>
 
 <div *ngIf="lineItems">
   <!-- Currently, payments are not created until submit. This will likely change in the future. -->
-  <ocm-payment-list *ngIf="payments" [payments]="payments?.Items"></ocm-payment-list>
+  <ocm-payment-list
+    *ngIf="payments"
+    [payments]="payments?.Items"
+    [order]="order"
+  ></ocm-payment-list>
   <div class="row mb-4">
     <div class="col-sm-12">
-      <small class="font-weight-bold text-muted text-uppercase"><span
-          translate>CHECKOUT.CHECKOUT_CONFIRM.SHIP_TO</span>:</small>
-      <ocm-address-card *ngIf="lineItems?.Items[0].ShippingAddress" [address]="lineItems?.Items[0].ShippingAddress"
-        addressTitle="Shipping Address">
+      <small class="font-weight-bold text-muted text-uppercase"
+        ><span translate>CHECKOUT.CHECKOUT_CONFIRM.SHIP_TO</span>:</small
+      >
+      <ocm-address-card
+        *ngIf="lineItems?.Items[0].ShippingAddress"
+        [address]="lineItems?.Items[0].ShippingAddress"
+        addressTitle="Shipping Address"
+      >
       </ocm-address-card>
     </div>
   </div>
-  <ocm-lineitem-table [lineItems]="lineItems?.Items" [readOnly]="true" [hideStatus]="true" class="my-3">
+  <ocm-lineitem-table
+    [lineItems]="lineItems?.Items"
+    [readOnly]="true"
+    [hideStatus]="true"
+    class="my-3"
+  >
   </ocm-lineitem-table>
   <form *ngIf="!isAnon" novalidate [formGroup]="form">
-    <textarea type="text" maxlength="2000"
-      placeholder="{{ 'CHECKOUT.CHECKOUT_PAYMENT.PURCHASE_ORDER_SUMMARY' | translate }}"
-      formControlName="comments" class="form-control">
+    <textarea
+      type="text"
+      maxlength="2000"
+      placeholder="{{
+        'CHECKOUT.CHECKOUT_PAYMENT.PURCHASE_ORDER_SUMMARY' | translate
+      }}"
+      formControlName="comments"
+      class="form-control"
+    >
     </textarea>
   </form>
 </div>

--- a/src/UI/Seller/src/app/orders/components/order-shipments/order-shipments.component.ts
+++ b/src/UI/Seller/src/app/orders/components/order-shipments/order-shipments.component.ts
@@ -338,8 +338,7 @@ export class OrderShipmentsComponent implements OnChanges {
         const quantityToShip =
           item.Quantity -
           item.QuantityShipped -
-          item.xp.StatusByQuantity['Backordered'] -
-          item.xp.StatusByQuantity['Canceled']
+          item.xp.StatusByQuantity['Backordered']
         if (quantityToShip) {
           this.shipmentForm.patchValue({
             LineItemData: {


### PR DESCRIPTION
1. Unable to submit order because payment-list was missing new input (order)
2. Ship all items was broken on admin due to line item status canceled no longer being a property
3. Order return complete failed because payment transaction xp was not adhering to the interface HSPaymentTransactionXp