### PR TITLE
Resolve duplicate files on build in recommended way

### DIFF
--- a/src/Middleware/integrations/OrderCloud.Integrations.Alerts/OrderCloud.Integrations.Alerts.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Alerts/OrderCloud.Integrations.Alerts.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.Avalara/OrderCloud.Integrations.Avalara.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Avalara/OrderCloud.Integrations.Avalara.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.AzureServiceBus/OrderCloud.Integrations.AzureServiceBus.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.AzureServiceBus/OrderCloud.Integrations.AzureServiceBus.csproj
@@ -5,17 +5,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Middleware/integrations/OrderCloud.Integrations.AzureStorage/OrderCloud.Integrations.AzureStorage.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.AzureStorage/OrderCloud.Integrations.AzureStorage.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.CMS/OrderCloud.Integrations.CMS.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.CMS/OrderCloud.Integrations.CMS.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.CardConnect/OrderCloud.Integrations.CardConnect.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.CardConnect/OrderCloud.Integrations.CardConnect.csproj
@@ -7,10 +7,6 @@
     <Authors>Sitecore</Authors>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Middleware/integrations/OrderCloud.Integrations.CosmosDB/OrderCloud.Integrations.CosmosDB.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.CosmosDB/OrderCloud.Integrations.CosmosDB.csproj
@@ -20,7 +20,6 @@
     </PackageReference>
     <PackageReference Include="Cosmonaut" Version="2.11.3" />
     <PackageReference Include="Cosmonaut.Extensions.Microsoft.DependencyInjection" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.10.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.CosmosDB/OrderCloud.Integrations.CosmosDB.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.CosmosDB/OrderCloud.Integrations.CosmosDB.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.EasyPost/OrderCloud.Integrations.EasyPost.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.EasyPost/OrderCloud.Integrations.EasyPost.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.Emails/OrderCloud.Integrations.Emails.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Emails/OrderCloud.Integrations.Emails.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.EnvironmentSeed/OrderCloud.Integrations.EnvironmentSeed.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.EnvironmentSeed/OrderCloud.Integrations.EnvironmentSeed.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.ExchangeRates/OrderCloud.Integrations.ExchangeRates.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.ExchangeRates/OrderCloud.Integrations.ExchangeRates.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
@@ -25,103 +21,103 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Icons\AUD.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\BGN.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\BRL.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\CAD.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\CHF.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\CNY.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\CZK.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\DKK.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\EUR.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\GBP.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\HKD.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\HRK.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\HUF.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\IDR.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\ILS.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\INR.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\ISK.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\JPY.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\KRW.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\MXN.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\MYR.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\NOK.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\NZD.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\PHP.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\PLN.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\RON.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\RUB.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\SEK.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\SGD.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\THB.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\TRY.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\USD.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <EmbeddedResource Include="Icons\ZAR.gif">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/src/Middleware/integrations/OrderCloud.Integrations.Orchestration/OrderCloud.Integrations.Orchestration.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Orchestration/OrderCloud.Integrations.Orchestration.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.Portal/OrderCloud.Integrations.Portal.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Portal/OrderCloud.Integrations.Portal.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.Reporting/OrderCloud.Integrations.Reporting.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Reporting/OrderCloud.Integrations.Reporting.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.SendGrid/OrderCloud.Integrations.SendGrid.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.SendGrid/OrderCloud.Integrations.SendGrid.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.Smarty/OrderCloud.Integrations.Smarty.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Smarty/OrderCloud.Integrations.Smarty.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.TaxJar/OrderCloud.Integrations.TaxJar.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.TaxJar/OrderCloud.Integrations.TaxJar.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.Vertex/OrderCloud.Integrations.Vertex.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Vertex/OrderCloud.Integrations.Vertex.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/integrations/OrderCloud.Integrations.Zoho/OrderCloud.Integrations.Zoho.csproj
+++ b/src/Middleware/integrations/OrderCloud.Integrations.Zoho/OrderCloud.Integrations.Zoho.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/src/Headstart.API/Headstart.API.csproj
+++ b/src/Middleware/src/Headstart.API/Headstart.API.csproj
@@ -6,10 +6,6 @@
     <LangVersion>8</LangVersion>
     <ApplicationInsightsResourceId>/subscriptions/736cd8bd-0185-4184-b3dd-8c372c076f3f/resourceGroups/Marketplace/providers/microsoft.insights/components/marketplace-middleware</ApplicationInsightsResourceId>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
   
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -55,7 +51,7 @@
 
   <ItemGroup>
     <Compile Update="Program.cs">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -68,13 +64,13 @@
   </ItemGroup>
   <ItemGroup>
     <Content Update="wwwroot\i18n\en.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Update="wwwroot\i18n\fr.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Update="wwwroot\i18n\jp.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
 </Project>

--- a/src/Middleware/src/Headstart.API/Startup.cs
+++ b/src/Middleware/src/Headstart.API/Startup.cs
@@ -15,7 +15,6 @@ using Headstart.Common.Services;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
@@ -64,7 +63,7 @@ namespace Headstart.API
             app.UseCatalystExceptionHandler();
             app.UseHttpsRedirection();
             app.UseRouting();
-            app.UseCors("integrationcors");
+            app.UseCors("middlewarecorspolicy");
             app.UseAuthorization();
             app.UseEndpoints(endpoints => endpoints.MapControllers());
             app.UseSwagger();
@@ -121,7 +120,6 @@ namespace Headstart.API
                  o.EnableEndpointRouting = false;
              })
             .ConfigureApiBehaviorOptions(o => o.SuppressModelStateInvalidFilter = true)
-            .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
             .AddNewtonsoftJson(options =>
             {
                 options.SerializerSettings.ContractResolver = new Newtonsoft.Json.Serialization.DefaultContractResolver();
@@ -130,7 +128,7 @@ namespace Headstart.API
             });
 
             services
-                .AddCors(o => o.AddPolicy("integrationcors", builder => { builder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader(); }))
+                .AddCors(o => o.AddPolicy("middlewarecorspolicy", builder => { builder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader(); }))
                 .AddSingleton<ISimpleCache, LazyCacheService>() // Replace LazyCacheService with RedisService if you have multiple server instances.
                 .AddSingleton<IFlurlClientFactory, PerBaseUrlFlurlClientFactory>()
 
@@ -220,10 +218,7 @@ namespace Headstart.API
                     List<string> xmlFiles = Directory.GetFiles(AppContext.BaseDirectory, "*.xml", SearchOption.TopDirectoryOnly).ToList();
                     xmlFiles.ForEach(xmlFile => c.IncludeXmlComments(xmlFile));
                 })
-                .AddSwaggerGenNewtonsoftSupport();
-
-            var serviceProvider = services.BuildServiceProvider();
-            services
+                .AddSwaggerGenNewtonsoftSupport()
                 .AddApplicationInsightsTelemetry(new ApplicationInsightsServiceOptions
                 {
                     EnableAdaptiveSampling = false, // retain all data

--- a/src/Middleware/src/Headstart.Common/Headstart.Common.csproj
+++ b/src/Middleware/src/Headstart.Common/Headstart.Common.csproj
@@ -8,9 +8,6 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/src/Headstart.Jobs/Headstart.Jobs.csproj
+++ b/src/Middleware/src/Headstart.Jobs/Headstart.Jobs.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/tests/Headstart.Tests/Headstart.Tests.csproj
+++ b/src/Middleware/tests/Headstart.Tests/Headstart.Tests.csproj
@@ -10,10 +10,6 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-  
   <ItemGroup>
     <Compile Remove="CreditCardCommandTests.cs" />
   </ItemGroup>

--- a/src/Middleware/tests/OrderCloud.Integrations.Avalara.Tests/OrderCloud.Integrations.Avalara.Tests.csproj
+++ b/src/Middleware/tests/OrderCloud.Integrations.Avalara.Tests/OrderCloud.Integrations.Avalara.Tests.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/tests/OrderCloud.Integrations.CardConnect.Tests/OrderCloud.Integrations.CardConnect.Tests.csproj
+++ b/src/Middleware/tests/OrderCloud.Integrations.CardConnect.Tests/OrderCloud.Integrations.CardConnect.Tests.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/tests/OrderCloud.Integrations.CosmosDB.Tests/OrderCloud.Integrations.CosmosDB.Tests.csproj
+++ b/src/Middleware/tests/OrderCloud.Integrations.CosmosDB.Tests/OrderCloud.Integrations.CosmosDB.Tests.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/tests/OrderCloud.Integrations.EasyPost.Tests/OrderCloud.Integrations.EasyPost.Tests.csproj
+++ b/src/Middleware/tests/OrderCloud.Integrations.EasyPost.Tests/OrderCloud.Integrations.EasyPost.Tests.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/tests/OrderCloud.Integrations.EnvironmentSeed.Tests/OrderCloud.Integrations.EnvironmentSeed.Tests.csproj
+++ b/src/Middleware/tests/OrderCloud.Integrations.EnvironmentSeed.Tests/OrderCloud.Integrations.EnvironmentSeed.Tests.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/tests/OrderCloud.Integrations.ExchangeRates.Tests/OrderCloud.Integrations.ExchangeRates.Tests.csproj
+++ b/src/Middleware/tests/OrderCloud.Integrations.ExchangeRates.Tests/OrderCloud.Integrations.ExchangeRates.Tests.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/src/Middleware/tests/OrderCloud.Integrations.SendGrid.Tests/OrderCloud.Integrations.SendGrid.Tests.csproj
+++ b/src/Middleware/tests/OrderCloud.Integrations.SendGrid.Tests/OrderCloud.Integrations.SendGrid.Tests.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
In a previous commit 50422304b1277a0a9b67d781b99788b8c3201e05 I suppressed errors for duplicate published output files to fix the build which was failing due to an error introduced in .net sdk 6.0.100

 I found out recently however that the recommended way of dealing with this is instead to not have duplicate output files which can be achieved by changing "CopyToOutputDirectory" from "Always" to "PreserveNewest". More info here: https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/duplicate-files-in-output#recommended-action