### PR TITLE
Fix for image upload issue

### DIFF
--- a/src/UI/SDK/files-changed-hash
+++ b/src/UI/SDK/files-changed-hash
@@ -1,1 +1,1 @@
-peWCBjv5UfpGNngAjG1aGNO1Ce4=
+n6maVYeE5P15ss6s26SBVkdAZqs=

--- a/src/UI/SDK/src/api/Assets.ts
+++ b/src/UI/SDK/src/api/Assets.ts
@@ -18,11 +18,11 @@ export default class Assets {
     * @param assetData required: File
     */
     public async CreateImage(assetData: FileData): Promise<RequiredDeep<ImageAsset>> {
-        return await httpClient.post('/assets/image', this.mapFileToFormData(assetData), { params: {} })
+        return await httpClient.post('/assets/image', this.mapFileToFormData(assetData), { headers: {'Content-Type': 'multipart/form-data'}})
     }
 
     public async CreateDocument(assetData: FileData): Promise<RequiredDeep<DocumentAsset>> {
-        return await httpClient.post('/assets/document', this.mapFileToFormData(assetData), { params: {} })
+        return await httpClient.post('/assets/document', this.mapFileToFormData(assetData), { headers: {'Content-Type': 'multipart/form-data'}})
     }
 
     /**

--- a/src/UI/SDK/src/utils/HttpClient.ts
+++ b/src/UI/SDK/src/utils/HttpClient.ts
@@ -149,14 +149,16 @@ class HttpClient {
   private _buildRequestConfig(
     config?: OcRequestConfig
   ): Promise<OcRequestConfig> {
+    const defaultHeaders = {
+      'Content-Type': 'application/json',
+    }
+    const configuredHeaders = config?.headers ? config.headers : defaultHeaders
     const sdkConfig = Configuration.Get()
     const requestConfig = {
       ...config,
       paramsSerializer,
       timeout: sdkConfig.timeoutInMilliseconds,
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: configuredHeaders
     }
     return this._addTokenToConfig(requestConfig)
   }


### PR DESCRIPTION
1) After axios upgraded to 1.2, we needed to specify the Content-Type in our request headers when it deviated from application/json (in the case of images/documents).
2) Adjusted SDK to allow for this.