### PR TITLE
upgrade to dotnetcore, node and others

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,8 @@ services:
       context: .
       dockerfile: docker/build/middleware/Dockerfile
       args:
-        BUILD_IMAGE: mcr.microsoft.com/dotnet/sdk:3.1-alpine
-        BASE_IMAGE: mcr.microsoft.com/dotnet/aspnet:3.1-alpine
+        BUILD_IMAGE: mcr.microsoft.com/dotnet/sdk:6.0-alpine3.14
+        BASE_IMAGE: mcr.microsoft.com/dotnet/aspnet:6.0-alpine3.14
         BUILD_CONFIGURATION: ${BUILD_CONFIGURATION}
     environment:
       ASPNETCORE_ENVIRONMENT: ${BUILD_CONFIGURATION}
@@ -117,6 +117,7 @@ services:
       StorageAccountSettings_ContainerNameCache: "${StorageAccountSettings_ContainerNameCache}"
       StorageAccountSettings_BlobContainerNameExchangeRates: "${StorageAccountSettings_ContainerNameExchangeRates}"
       StorageAccountSettings_ContainerNameTranslations: "${StorageAccountSettings_ContainerNameTranslations}"
+      StorageAccountSettings_BlobPrimaryEndpoint: "${StorageAccountSettings_BlobPrimaryEndpoint}"
 
       UI_BaseAdminUrl: "http://${SELLER_HOST}"
 
@@ -155,7 +156,7 @@ services:
       context: .
       dockerfile: docker/build/UI/Dockerfile
       args:
-        BASE_IMAGE: node:12.16.3-alpine
+        BASE_IMAGE: node:12.20.0-alpine
         ROLE: Seller
     labels:
       - "traefik.enable=true"
@@ -184,7 +185,7 @@ services:
       context: .
       dockerfile: docker/build/UI/Dockerfile
       args:
-        BASE_IMAGE: node:12.16.3-alpine
+        BASE_IMAGE: node:12.20.0-alpine
         ROLE: Buyer
     labels:
       - "traefik.enable=true"

--- a/docker/build/middleware/Dockerfile
+++ b/docker/build/middleware/Dockerfile
@@ -24,6 +24,9 @@ RUN npm install -g json
 
 RUN apk add --no-cache --upgrade bash curl dos2unix
 
+# this will support multilingual
+RUN apk add --no-cache icu-libs
+
 WORKDIR /app
 
 COPY --from=build /out/middleware .

--- a/src/Middleware/src/Headstart.API/runtimeconfig.template.json
+++ b/src/Middleware/src/Headstart.API/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+  "configProperties": {
+    "System.Globalization.Invariant": false
+  }
+}


### PR DESCRIPTION
Headstart docker has couple of issues at this moment:

> Angular: The current node 12.16.3-alpine version is not supported with Angular
> Dotnetsdk: Headstart middleware uses dotnet 6.0, therefore needs to update the dotnetcore version 
> Current Middleware doesnt support multilinugal. This support is being added by adding ""System.Globalization.Invariant": false" and icu-libs 